### PR TITLE
Add agent reasoning loop with basic tools

### DIFF
--- a/src/Agent.Runtime/Program.cs
+++ b/src/Agent.Runtime/Program.cs
@@ -1,4 +1,42 @@
+using Agent.Runtime.Tools;
 using Shared.Models;
 
 var config = new AgentConfig("runtime");
 Console.WriteLine($"Starting agent: {config.Name}");
+
+await RunAsync(args);
+
+static async Task RunAsync(string[] args)
+{
+    string goal = args.Length > 0
+        ? string.Join(" ", args)
+        : Environment.GetEnvironmentVariable("GOAL") ?? "echo hello";
+
+    Console.WriteLine($"Goal received: {goal}");
+
+    while (true)
+    {
+        var parts = goal.Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0)
+        {
+            Console.WriteLine("No goal specified.");
+            break;
+        }
+
+        var toolName = parts[0];
+        var toolInput = parts.Length > 1 ? parts[1] : string.Empty;
+
+        var tool = ToolRegistry.Get(toolName);
+        if (tool is null)
+        {
+            Console.WriteLine($"Tool '{toolName}' not found.");
+            break;
+        }
+
+        var result = await tool.ExecuteAsync(toolInput);
+        Console.WriteLine(result);
+
+        // For this example we complete after one tool execution
+        break;
+    }
+}

--- a/src/Agent.Runtime/Tools/EchoTool.cs
+++ b/src/Agent.Runtime/Tools/EchoTool.cs
@@ -1,0 +1,11 @@
+namespace Agent.Runtime.Tools;
+
+public class EchoTool : ITool
+{
+    public string Name => "echo";
+
+    public Task<string> ExecuteAsync(string input)
+    {
+        return Task.FromResult($"Echo: {input}");
+    }
+}

--- a/src/Agent.Runtime/Tools/ITool.cs
+++ b/src/Agent.Runtime/Tools/ITool.cs
@@ -1,0 +1,7 @@
+namespace Agent.Runtime.Tools;
+
+public interface ITool
+{
+    string Name { get; }
+    Task<string> ExecuteAsync(string input);
+}

--- a/src/Agent.Runtime/Tools/ToolRegistry.cs
+++ b/src/Agent.Runtime/Tools/ToolRegistry.cs
@@ -1,0 +1,25 @@
+using System.Collections.Concurrent;
+
+namespace Agent.Runtime.Tools;
+
+public static class ToolRegistry
+{
+    private static readonly ConcurrentDictionary<string, ITool> _tools = new();
+
+    static ToolRegistry()
+    {
+        // Register built-in tools
+        Register(new EchoTool());
+    }
+
+    public static void Register(ITool tool)
+    {
+        _tools[tool.Name] = tool;
+    }
+
+    public static ITool? Get(string name)
+    {
+        _tools.TryGetValue(name, out var tool);
+        return tool;
+    }
+}


### PR DESCRIPTION
## Summary
- review docs/architecture and README next steps
- implement simple agent reasoning loop in `Agent.Runtime` console app
- add `ITool` interface and `EchoTool`
- register tools with `ToolRegistry`

## Testing
- `dotnet build WorldSeed.sln`
- `dotnet run --project src/Agent.Runtime -- echo "Hello world"`

------
https://chatgpt.com/codex/tasks/task_e_687520c026e4832dbe16f0a47edc413f