### PR TITLE
Add sandbox profile documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,13 @@ Visit: http://localhost:5000 (Blazor Server UI)
 
 3. Orchestrator spins up a Docker container:
 
-docker run -d --rm --name agent-{id} myagent:latest --goal="..."
+```bash
+docker run -d --rm \
+  --name agent-{id} \
+  --security-opt seccomp=./docker/profiles/seccomp-agent.json \
+  --security-opt apparmor=worldseed-agent \
+  myagent:latest --goal="..."
+```
 
 
 4. Agent begins loop: Thought → Tool → Action → Memory

--- a/docker/profiles/seccomp-agent.json
+++ b/docker/profiles/seccomp-agent.json
@@ -1,0 +1,9 @@
+{
+    "defaultAction": "SCMP_ACT_ERRNO",
+    "architectures": ["SCMP_ARCH_X86_64"],
+    "syscalls": [
+        {"names": ["exit", "exit_group", "read", "write", "futex"], "action": "SCMP_ACT_ALLOW"},
+        {"names": ["brk", "mmap", "mprotect", "munmap"], "action": "SCMP_ACT_ALLOW"},
+        {"names": ["clone", "execve"], "action": "SCMP_ACT_ALLOW"}
+    ]
+}

--- a/docker/profiles/worldseed-agent.apparmor
+++ b/docker/profiles/worldseed-agent.apparmor
@@ -1,0 +1,9 @@
+#include <tunables/global>
+
+profile worldseed-agent flags=(attach_disconnected) {
+    # Basic read/write access within the container
+    /agent/** rwk,
+    /usr/bin/dotnet ix,
+    network inet stream,
+    capability net_bind_service,
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,3 +6,15 @@ This document outlines the high-level architecture for the WorldSeed template.
 - **Orchestrator.UI** - Blazor Web App providing dashboard and task interface.
 - **Agent.Runtime** - Console app running inside Docker container executing agent logic.
 - **Shared** - Common DTOs and utilities shared between projects.
+
+## Sandbox Setup
+
+Agents run in isolated Docker containers with the following safeguards:
+
+- **Resource Limits** – CPU and memory quotas applied per container.
+- **Volumes** – a dedicated `/agent` volume is mounted for state.
+- **Network** – can be disabled per agent for offline execution.
+- **Seccomp Profile** – `docker/profiles/seccomp-agent.json` restricts system calls.
+- **AppArmor** – profile `worldseed-agent` confines filesystem and network access.
+
+The orchestrator passes these options when launching each container.


### PR DESCRIPTION
## Summary
- add seccomp and AppArmor profiles for agents
- document sandbox setup in architecture notes
- update README docker run example with security options

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build WorldSeed.sln`

------
https://chatgpt.com/codex/tasks/task_e_687520c4aba8832dac6b341f9e8654ff