### PR TITLE
Implement basic per-agent logging

### DIFF
--- a/src/Agent.Runtime/Logging/CompositeAgentLogger.cs
+++ b/src/Agent.Runtime/Logging/CompositeAgentLogger.cs
@@ -1,0 +1,19 @@
+namespace Agent.Runtime.Logging;
+
+public class CompositeAgentLogger : IAgentLogger
+{
+    private readonly IAgentLogger[] _loggers;
+
+    public CompositeAgentLogger(params IAgentLogger[] loggers)
+    {
+        _loggers = loggers;
+    }
+
+    public async Task LogAsync(string message)
+    {
+        foreach (var logger in _loggers)
+        {
+            await logger.LogAsync(message);
+        }
+    }
+}

--- a/src/Agent.Runtime/Logging/ConsoleAgentLogger.cs
+++ b/src/Agent.Runtime/Logging/ConsoleAgentLogger.cs
@@ -1,0 +1,10 @@
+namespace Agent.Runtime.Logging;
+
+public class ConsoleAgentLogger : IAgentLogger
+{
+    public Task LogAsync(string message)
+    {
+        Console.WriteLine(message);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Agent.Runtime/Logging/HttpAgentLogger.cs
+++ b/src/Agent.Runtime/Logging/HttpAgentLogger.cs
@@ -1,0 +1,23 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace Agent.Runtime.Logging;
+
+public class HttpAgentLogger : IAgentLogger
+{
+    private readonly HttpClient _client;
+    private readonly string _agentId;
+
+    public HttpAgentLogger(string agentId, HttpClient? client = null)
+    {
+        _client = client ?? new HttpClient();
+        _agentId = agentId;
+    }
+
+    public async Task LogAsync(string message)
+    {
+        var payload = JsonSerializer.Serialize(new { message });
+        await _client.PostAsync($"http://localhost:5000/api/agent/{_agentId}/logs",
+            new StringContent(payload, System.Text.Encoding.UTF8, "application/json"));
+    }
+}

--- a/src/Agent.Runtime/Logging/IAgentLogger.cs
+++ b/src/Agent.Runtime/Logging/IAgentLogger.cs
@@ -1,0 +1,6 @@
+namespace Agent.Runtime.Logging;
+
+public interface IAgentLogger
+{
+    Task LogAsync(string message);
+}

--- a/src/Agent.Runtime/Program.cs
+++ b/src/Agent.Runtime/Program.cs
@@ -1,4 +1,15 @@
 using Shared.Models;
+using Agent.Runtime.Logging;
 
 var config = new AgentConfig("runtime");
-Console.WriteLine($"Starting agent: {config.Name}");
+var logger = new CompositeAgentLogger(
+    new ConsoleAgentLogger(),
+    new HttpAgentLogger(config.Name));
+
+await logger.LogAsync($"Starting agent: {config.Name}");
+
+for (var i = 0; i < 3; i++)
+{
+    await logger.LogAsync($"Agent step {i}");
+    await Task.Delay(1000);
+}

--- a/src/Orchestrator.API/Controllers/AgentController.cs
+++ b/src/Orchestrator.API/Controllers/AgentController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using Orchestrator.API.Logging;
 using Shared.Models;
 
 namespace Orchestrator.API.Controllers;
@@ -7,6 +8,29 @@ namespace Orchestrator.API.Controllers;
 [Route("api/[controller]")]
 public class AgentController : ControllerBase
 {
+    private readonly IAgentLogStore _logStore;
+
+    public AgentController(IAgentLogStore logStore)
+    {
+        _logStore = logStore;
+    }
+
     [HttpGet]
     public IActionResult GetDefaultConfig() => Ok(new AgentConfig("default"));
+
+    [HttpPost("{id}/logs")]
+    public IActionResult AddLog(string id, [FromBody] AgentLogEntry entry)
+    {
+        _logStore.Add(id, entry.Message);
+        return Accepted();
+    }
+
+    [HttpGet("{id}/logs")]
+    public IActionResult GetLogs(string id)
+    {
+        var logs = _logStore.Get(id);
+        return Ok(logs);
+    }
 }
+
+public record AgentLogEntry(string Message);

--- a/src/Orchestrator.API/Logging/IAgentLogStore.cs
+++ b/src/Orchestrator.API/Logging/IAgentLogStore.cs
@@ -1,0 +1,7 @@
+namespace Orchestrator.API.Logging;
+
+public interface IAgentLogStore
+{
+    void Add(string agentId, string message);
+    IReadOnlyList<string> Get(string agentId);
+}

--- a/src/Orchestrator.API/Logging/InMemoryAgentLogStore.cs
+++ b/src/Orchestrator.API/Logging/InMemoryAgentLogStore.cs
@@ -1,0 +1,24 @@
+using System.Collections.Concurrent;
+
+namespace Orchestrator.API.Logging;
+
+public class InMemoryAgentLogStore : IAgentLogStore
+{
+    private readonly ConcurrentDictionary<string, List<string>> _logs = new();
+
+    public void Add(string agentId, string message)
+    {
+        var list = _logs.GetOrAdd(agentId, _ => new List<string>());
+        lock (list)
+        {
+            list.Add(message);
+        }
+    }
+
+    public IReadOnlyList<string> Get(string agentId)
+    {
+        return _logs.TryGetValue(agentId, out var list)
+            ? list.AsReadOnly()
+            : Array.Empty<string>();
+    }
+}

--- a/src/Orchestrator.API/Program.cs
+++ b/src/Orchestrator.API/Program.cs
@@ -5,6 +5,8 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddControllers();
+builder.Services.AddSingleton<Orchestrator.API.Logging.IAgentLogStore,
+    Orchestrator.API.Logging.InMemoryAgentLogStore>();
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Summary
- extend README's "Next Steps" suggestion by implementing logging
- add in-memory agent log store with API endpoints
- add logging service and HTTP logger for Agent.Runtime
- register services in Orchestrator.API

## Testing
- `dotnet build WorldSeed.sln`

------
https://chatgpt.com/codex/tasks/task_e_687520c5f548832da49619e10a504822