### PR TITLE
Implement basic agent management

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,14 @@ curl -X POST "http://localhost:5000/api/agent/start" \
      -d '{"goal":"echo hello"}'
 ```
 
+```bash
+# list running agents
+curl http://localhost:5000/api/agent/list
+
+# stop an agent
+curl -X POST http://localhost:5000/api/agent/<id>/stop
+```
+
 🌐 Access Dashboard
 
 Visit: http://localhost:5000 (Blazor Server UI)

--- a/scripts/devtools.ps1
+++ b/scripts/devtools.ps1
@@ -1,9 +1,14 @@
 param(
-    [string]$Action
+    [string]$Action,
+    [string]$Id
 )
 
 switch ($Action) {
     'start' { dotnet run --project ../src/Orchestrator.API }
     'ui'    { dotnet run --project ../src/Orchestrator.UI }
-    default { Write-Host "Usage: devtools.ps1 [start|ui]" }
+    'stop'  {
+        if (-not $Id) { Write-Host "Specify agent id"; break }
+        Invoke-RestMethod -Method Post -Uri "http://localhost:5000/api/agent/$Id/stop"
+    }
+    default { Write-Host "Usage: devtools.ps1 [start|ui|stop <id>]" }
 }

--- a/src/Orchestrator.API/Controllers/AgentController.cs
+++ b/src/Orchestrator.API/Controllers/AgentController.cs
@@ -25,10 +25,24 @@ public class AgentController : ControllerBase
         return Ok(config);
     }
 
+    [HttpGet("list")]
+    public IActionResult List()
+    {
+        var agents = _orchestrator.ListAgents();
+        return Ok(agents);
+    }
+
     [HttpPost("start")]
     public async Task<IActionResult> Start([FromBody] StartAgentRequest request)
     {
         var id = await _orchestrator.StartAgentAsync(request.Goal, request.Type);
         return Ok(new { id });
+    }
+
+    [HttpPost("{id}/stop")]
+    public async Task<IActionResult> Stop(string id)
+    {
+        await _orchestrator.StopAgentAsync(id);
+        return Ok();
     }
 }

--- a/src/Orchestrator.UI/Components/Layout/NavMenu.razor
+++ b/src/Orchestrator.UI/Components/Layout/NavMenu.razor
@@ -25,6 +25,11 @@
                 <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Weather
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="agents">
+                <span class="bi bi-robot" aria-hidden="true"></span> Agents
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/src/Orchestrator.UI/Components/Pages/Agents.razor
+++ b/src/Orchestrator.UI/Components/Pages/Agents.razor
@@ -1,0 +1,65 @@
+@page "/agents"
+@using Shared.Models
+@inject HttpClient Http
+
+<PageTitle>Agents</PageTitle>
+
+<h1>Agents</h1>
+
+<div class="mb-3">
+    <input class="form-control" placeholder="Goal" @bind="goal" />
+</div>
+<div class="mb-3">
+    <select class="form-select" @bind="selectedType">
+        @foreach (var type in Enum.GetValues<AgentType>())
+        {
+            <option value="@type">@type</option>
+        }
+    </select>
+</div>
+<button class="btn btn-primary" @onclick="StartAgent">Start Agent</button>
+
+<h2 class="mt-4">Running Agents</h2>
+<ul>
+    @foreach (var agent in agents)
+    {
+        <li>@agent.Id (@agent.Type)
+            <button class="btn btn-sm btn-danger ms-2" @onclick="() => StopAgent(agent.Id)">Stop</button>
+        </li>
+    }
+</ul>
+
+@code {
+    private string goal = string.Empty;
+    private AgentType selectedType = AgentType.Default;
+    private List<AgentInfo> agents = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAgents();
+    }
+
+    private async Task LoadAgents()
+    {
+        var result = await Http.GetFromJsonAsync<List<AgentInfo>>("api/agent/list");
+        if (result != null)
+            agents = result;
+    }
+
+    private async Task StartAgent()
+    {
+        var request = new StartAgentRequest(goal, selectedType);
+        var response = await Http.PostAsJsonAsync("api/agent/start", request);
+        if (response.IsSuccessStatusCode)
+        {
+            await LoadAgents();
+            goal = string.Empty;
+        }
+    }
+
+    private async Task StopAgent(string id)
+    {
+        await Http.PostAsync($"api/agent/{id}/stop", null);
+        await LoadAgents();
+    }
+}

--- a/src/Orchestrator.UI/Components/_Imports.razor
+++ b/src/Orchestrator.UI/Components/_Imports.razor
@@ -8,3 +8,4 @@
 @using Microsoft.JSInterop
 @using Orchestrator.UI
 @using Orchestrator.UI.Components
+@using Shared.Models

--- a/src/Orchestrator.UI/Program.cs
+++ b/src/Orchestrator.UI/Program.cs
@@ -6,6 +6,8 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 
+builder.Services.AddHttpClient();
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.

--- a/src/Shared/Models/AgentInfo.cs
+++ b/src/Shared/Models/AgentInfo.cs
@@ -1,0 +1,3 @@
+namespace Shared.Models;
+
+public record AgentInfo(string Id, AgentType Type);


### PR DESCRIPTION
## Summary
- implement server-side list & stop endpoints
- add simple Blazor page for starting/stopping agents
- wire up HTTP client and navigation
- update devtools script and docs

## Testing
- `dotnet build WorldSeed.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6875284bcdd4832d9b4baa17c7eb12fe