### PR TITLE
Enable local agent mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ dotnet build WorldSeed.sln
 
 Use `scripts/devtools.ps1` for simple dev workflows.
 
+### Running without Docker
+
+If Docker is not available on your system you can still run the agents locally.
+Set the environment variable `USE_LOCAL_AGENT=1` before starting the orchestrator
+and it will launch agent processes directly using `dotnet run` instead of
+spinning up containers.
+
 ## ⚙️ Architecture
 
 ```text

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,11 @@ This document outlines the high-level architecture for the WorldSeed template.
 
 ## Sandbox Setup
 
-Agents run in isolated Docker containers with the following safeguards:
+Agents normally run in isolated Docker containers with the following safeguards.
+When Docker is unavailable the orchestrator can fall back to launching the agent
+process locally.
+
+Container safeguards include:
 
 - **Resource Limits** – CPU and memory quotas applied per container.
 - **Volumes** – a dedicated `/agent` volume is mounted for state.

--- a/src/Orchestrator.API/Services/AgentOrchestrator.cs
+++ b/src/Orchestrator.API/Services/AgentOrchestrator.cs
@@ -3,23 +3,55 @@ using Docker.DotNet.Models;
 using Shared.Models;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 
 namespace Orchestrator.API.Services;
 
 public class AgentOrchestrator
 {
-    private readonly DockerClient _docker;
+    private readonly DockerClient? _docker;
+    private readonly bool _useLocal;
     private const string ImageName = "worldseed-agent";
     private readonly ConcurrentDictionary<string, AgentInfo> _agents = new();
+    private readonly ConcurrentDictionary<string, Process> _processes = new();
 
     public AgentOrchestrator()
     {
-        _docker = new DockerClientConfiguration().CreateClient();
+        _useLocal = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("USE_LOCAL_AGENT"));
+        if (!_useLocal)
+        {
+            try
+            {
+                _docker = new DockerClientConfiguration().CreateClient();
+                // ping to verify connection
+                _docker.System.PingAsync().GetAwaiter().GetResult();
+            }
+            catch
+            {
+                _useLocal = true;
+            }
+        }
     }
 
     public async Task<string> StartAgentAsync(string goal, AgentType type = AgentType.Default)
     {
+        if (_useLocal)
+        {
+            var id = Guid.NewGuid().ToString("N");
+            var psi = new ProcessStartInfo("dotnet", $"run --project ../../src/Agent.Runtime -- {goal}")
+            {
+                WorkingDirectory = Path.Combine(Directory.GetCurrentDirectory(), "..", "Agent.Runtime"),
+                RedirectStandardOutput = false,
+                RedirectStandardError = false,
+            };
+
+            var proc = Process.Start(psi) ?? throw new InvalidOperationException("Failed to start local agent process");
+            _processes[id] = proc;
+            _agents[id] = new AgentInfo(id, type);
+            return id;
+        }
+
         // ensure image exists
         await EnsureImageAsync();
 
@@ -28,7 +60,7 @@ public class AgentOrchestrator
             config = new AgentConfig("agent", type);
 
         var volumeName = $"agent-{Guid.NewGuid():N}";
-        await _docker.Volumes.CreateAsync(new VolumesCreateParameters
+        await _docker!.Volumes.CreateAsync(new VolumesCreateParameters
         {
             Name = volumeName
         });
@@ -74,15 +106,33 @@ public class AgentOrchestrator
 
     public async Task StopAgentAsync(string id)
     {
+        if (_useLocal)
+        {
+            if (_processes.TryRemove(id, out var proc))
+            {
+                try
+                {
+                    proc.Kill(true);
+                }
+                catch { }
+                proc.Dispose();
+            }
+            _agents.TryRemove(id, out _);
+            return;
+        }
+
         if (_agents.TryRemove(id, out _))
         {
-            await _docker.Containers.StopContainerAsync(id, new ContainerStopParameters());
+            await _docker!.Containers.StopContainerAsync(id, new ContainerStopParameters());
         }
     }
 
     private async Task EnsureImageAsync()
     {
-        var images = await _docker.Images.ListImagesAsync(new ImagesListParameters());
+        if (_useLocal)
+            return;
+
+        var images = await _docker!.Images.ListImagesAsync(new ImagesListParameters());
         if (images.Any(i => i.RepoTags != null && i.RepoTags.Contains(ImageName)))
             return;
 


### PR DESCRIPTION
## Summary
- add optional local agent execution mode
- mention local mode in README
- document fallback in architecture doc

## Testing
- `dotnet format --no-restore`
- `dotnet build WorldSeed.sln --no-restore`
- `dotnet test WorldSeed.sln --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68752c66ea9c832da11b7727ff6541cf