### PR TITLE
Add initial unit tests

### DIFF
--- a/tests/WorldSeed.Tests/AgentProfilesTests.cs
+++ b/tests/WorldSeed.Tests/AgentProfilesTests.cs
@@ -1,0 +1,26 @@
+using Shared.Models;
+
+namespace WorldSeed.Tests;
+
+public class AgentProfilesTests
+{
+    [Theory]
+    [InlineData(AgentType.Default)]
+    [InlineData(AgentType.Research)]
+    [InlineData(AgentType.Helper)]
+    public void TryGetProfile_ReturnsProfile(AgentType type)
+    {
+        var result = AgentProfiles.TryGetProfile(type, out var config);
+        Assert.True(result);
+        Assert.NotNull(config);
+        Assert.Equal(type, config!.Type);
+    }
+
+    [Fact]
+    public void TryGetProfile_Unknown_ReturnsFalse()
+    {
+        var result = AgentProfiles.TryGetProfile((AgentType)999, out var config);
+        Assert.False(result);
+        Assert.Null(config);
+    }
+}

--- a/tests/WorldSeed.Tests/GlobalUsings.cs
+++ b/tests/WorldSeed.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/WorldSeed.Tests/InMemoryRepositoryTests.cs
+++ b/tests/WorldSeed.Tests/InMemoryRepositoryTests.cs
@@ -1,0 +1,28 @@
+using Orchestrator.API.Data;
+using Shared.Models;
+
+namespace WorldSeed.Tests;
+
+public class InMemoryRepositoryTests
+{
+    [Fact]
+    public void AddAndGetAgent_Works()
+    {
+        var repo = new InMemoryAgentRepository();
+        var agent = new AgentInfo("id", AgentType.Default);
+        repo.Add(agent);
+        var retrieved = repo.Get("id");
+        Assert.Equal(agent, retrieved);
+        Assert.Single(repo.GetAll());
+    }
+
+    [Fact]
+    public void RemoveAgent_Works()
+    {
+        var repo = new InMemoryAgentRepository();
+        var agent = new AgentInfo("id", AgentType.Default);
+        repo.Add(agent);
+        repo.Remove("id");
+        Assert.Empty(repo.GetAll());
+    }
+}

--- a/tests/WorldSeed.Tests/InMemoryUnitOfWorkTests.cs
+++ b/tests/WorldSeed.Tests/InMemoryUnitOfWorkTests.cs
@@ -1,0 +1,22 @@
+using Orchestrator.API.Data;
+using Shared.Models;
+
+namespace WorldSeed.Tests;
+
+public class InMemoryUnitOfWorkTests
+{
+    [Fact]
+    public async Task SaveChangesAsync_DoesNothing()
+    {
+        var uow = new InMemoryUnitOfWork();
+        await uow.SaveChangesAsync();
+        // Should not throw
+    }
+
+    [Fact]
+    public void AgentsRepository_IsAccessible()
+    {
+        var uow = new InMemoryUnitOfWork();
+        Assert.NotNull(uow.Agents);
+    }
+}

--- a/tests/WorldSeed.Tests/LLMProviderTests.cs
+++ b/tests/WorldSeed.Tests/LLMProviderTests.cs
@@ -1,0 +1,14 @@
+using Shared.LLM;
+
+namespace WorldSeed.Tests;
+
+public class LLMProviderTests
+{
+    [Fact]
+    public async Task MockProvider_ReturnsMockResponse()
+    {
+        var provider = new MockOpenAIProvider("test");
+        var result = await provider.CompleteAsync("prompt");
+        Assert.Equal("test: prompt", result);
+    }
+}

--- a/tests/WorldSeed.Tests/MessageHubTests.cs
+++ b/tests/WorldSeed.Tests/MessageHubTests.cs
@@ -1,0 +1,16 @@
+using Shared.Messaging;
+
+namespace WorldSeed.Tests;
+
+public class MessageHubTests
+{
+    [Fact]
+    public void SendAndReceive_ShouldDeliverMessages()
+    {
+        var id = Guid.NewGuid().ToString();
+        MessageHub.Send(id, "hello");
+        var msgs = MessageHub.Receive(id);
+        Assert.Single(msgs);
+        Assert.Equal("hello", msgs[0]);
+    }
+}

--- a/tests/WorldSeed.Tests/ToolRegistryTests.cs
+++ b/tests/WorldSeed.Tests/ToolRegistryTests.cs
@@ -1,0 +1,33 @@
+using Agent.Runtime.Tools;
+using Shared.LLM;
+
+namespace WorldSeed.Tests;
+
+public class ToolRegistryTests
+{
+    [Fact]
+    public void Initialize_RegistersBuiltInTools()
+    {
+        ToolRegistry.Initialize(new MockOpenAIProvider());
+
+        Assert.NotNull(ToolRegistry.Get("echo"));
+        Assert.NotNull(ToolRegistry.Get("chat"));
+    }
+
+    [Fact]
+    public void Register_CustomTool_IsRetrievable()
+    {
+        ToolRegistry.Initialize(new MockOpenAIProvider());
+        var custom = new CustomTool();
+        ToolRegistry.Register(custom);
+
+        var retrieved = ToolRegistry.Get("custom");
+        Assert.Equal(custom, retrieved);
+    }
+
+    private class CustomTool : ITool
+    {
+        public string Name => "custom";
+        public Task<string> ExecuteAsync(string input) => Task.FromResult(input);
+    }
+}

--- a/tests/WorldSeed.Tests/WorldSeed.Tests.csproj
+++ b/tests/WorldSeed.Tests/WorldSeed.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Shared\Shared.csproj" />
+    <ProjectReference Include="..\..\src\Agent.Runtime\Agent.Runtime.csproj" />
+    <ProjectReference Include="..\..\src\Orchestrator.API\Orchestrator.API.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- add xunit test project
- test `MessageHub`, `AgentProfiles`, `ToolRegistry`, `LLM` mock provider
- test in-memory repository and unit of work

## Testing
- `dotnet build WorldSeed.sln`
- `dotnet test tests/WorldSeed.Tests/WorldSeed.Tests.csproj`
- `dotnet publish src/Agent.Runtime/Agent.Runtime.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_687539a5e57c832dbd9fd53c55fd269b