### PR TITLE
Add orchestrator tests and mock data

### DIFF
--- a/src/Orchestrator.API/Services/AgentOrchestrator.cs
+++ b/src/Orchestrator.API/Services/AgentOrchestrator.cs
@@ -41,9 +41,16 @@ public class AgentOrchestrator
         if (_useLocal)
         {
             var id = Guid.NewGuid().ToString("N");
-            var psi = new ProcessStartInfo("dotnet", $"run --project ../../src/Agent.Runtime -- {goal}")
+            var runtimeDir = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../../src/Agent.Runtime"));
+            if (!Directory.Exists(runtimeDir))
             {
-                WorkingDirectory = Path.Combine(Directory.GetCurrentDirectory(), "..", "Agent.Runtime"),
+                runtimeDir = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), "src", "Agent.Runtime"));
+            }
+
+            var projectPath = Path.Combine(runtimeDir, "Agent.Runtime.csproj");
+            var psi = new ProcessStartInfo("dotnet", $"run --project {projectPath} -- {goal}")
+            {
+                WorkingDirectory = runtimeDir,
                 RedirectStandardOutput = false,
                 RedirectStandardError = false,
             };

--- a/tests/WorldSeed.Tests/AgentOrchestratorTests.cs
+++ b/tests/WorldSeed.Tests/AgentOrchestratorTests.cs
@@ -1,0 +1,25 @@
+using Orchestrator.API.Services;
+using Shared.Models;
+
+namespace WorldSeed.Tests;
+
+public class AgentOrchestratorTests
+{
+    [Fact]
+    public async Task StartAndStopLocalAgent_Works()
+    {
+        Environment.SetEnvironmentVariable("USE_LOCAL_AGENT", "1");
+        var uow = new Orchestrator.API.Data.InMemoryUnitOfWork();
+        var orchestrator = new AgentOrchestrator(uow);
+
+        var goalPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../mock-data/sample-goal.txt"));
+        var goal = await File.ReadAllTextAsync(goalPath);
+        var id = await orchestrator.StartAgentAsync(goal.Trim());
+
+        Assert.Contains(uow.Agents.GetAll(), a => a.Id == id);
+
+        await orchestrator.StopAgentAsync(id);
+
+        Assert.DoesNotContain(uow.Agents.GetAll(), a => a.Id == id);
+    }
+}

--- a/tests/mock-data/sample-goal.txt
+++ b/tests/mock-data/sample-goal.txt
@@ -1,0 +1,1 @@
+echo hello from mock data


### PR DESCRIPTION
## Summary
- test that orchestrator can start and stop a local agent
- make local agent path resolution robust in `AgentOrchestrator`
- provide sample mock goal used by test

## Testing
- `dotnet test tests/WorldSeed.Tests/WorldSeed.Tests.csproj --logger "trx"`

------
https://chatgpt.com/codex/tasks/task_e_687540350e68832da6fd5bd8ee7375b4