### PR TITLE
Add agent logs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ Task submission
 
 Real-time log and memory inspection
 
+The UI now includes a **Logs** page that polls the API for messages from each
+agent and displays them in real time.
+
 
 
 3. Agent.Runtime

--- a/src/Orchestrator.UI/Components/Layout/NavMenu.razor
+++ b/src/Orchestrator.UI/Components/Layout/NavMenu.razor
@@ -30,6 +30,11 @@
                 <span class="bi bi-robot" aria-hidden="true"></span> Agents
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="logs">
+                <span class="bi bi-journal-text" aria-hidden="true"></span> Logs
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/src/Orchestrator.UI/Components/Pages/Logs.razor
+++ b/src/Orchestrator.UI/Components/Pages/Logs.razor
@@ -1,0 +1,83 @@
+@page "/logs"
+@using Shared.Models
+@inject HttpClient Http
+@implements IDisposable
+
+<PageTitle>Logs</PageTitle>
+
+<h1>Agent Logs</h1>
+
+<div class="mb-3">
+    <select class="form-select" value="@selectedAgentId" @onchange="OnAgentChanged">
+        <option value="">-- Select Agent --</option>
+        @foreach (var agent in agents)
+        {
+            <option value="@agent.Id">@agent.Id (@agent.Type)</option>
+        }
+    </select>
+</div>
+
+@if (!string.IsNullOrEmpty(selectedAgentId))
+{
+    <pre class="border p-2" style="height:300px; overflow-y:auto">@string.Join("\n", messages)</pre>
+}
+
+@code {
+    private List<AgentInfo> agents = new();
+    private string? selectedAgentId;
+    private readonly List<string> messages = new();
+    private CancellationTokenSource? _cts;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAgents();
+    }
+
+    private async Task LoadAgents()
+    {
+        var result = await Http.GetFromJsonAsync<List<AgentInfo>>("api/agent/list");
+        if (result != null)
+            agents = result;
+    }
+
+    private void OnAgentChanged(ChangeEventArgs e)
+    {
+        _cts?.Cancel();
+        messages.Clear();
+        selectedAgentId = e.Value?.ToString();
+        if (!string.IsNullOrEmpty(selectedAgentId))
+        {
+            _cts = new CancellationTokenSource();
+            _ = PollLogsAsync(_cts.Token);
+        }
+    }
+
+    private async Task PollLogsAsync(CancellationToken token)
+    {
+        var timer = new PeriodicTimer(TimeSpan.FromSeconds(2));
+        try
+        {
+            while (await timer.WaitForNextTickAsync(token))
+            {
+                await RefreshLogs();
+                await InvokeAsync(StateHasChanged);
+            }
+        }
+        catch (OperationCanceledException) { }
+    }
+
+    private async Task RefreshLogs()
+    {
+        if (string.IsNullOrEmpty(selectedAgentId))
+            return;
+
+        var result = await Http.GetFromJsonAsync<List<string>>($"api/message/{selectedAgentId}");
+        if (result != null && result.Count > 0)
+            messages.AddRange(result);
+    }
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+    }
+}


### PR DESCRIPTION
## Summary
- implement a logs page in the Blazor UI that polls `/api/message/{id}` for agent messages
- expose the new page through the navigation menu
- document the logs page in the README

## Testing
- `dotnet build WorldSeed.sln`
- `dotnet test tests/WorldSeed.Tests/WorldSeed.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68754270edac832da2001e1841929ee4