### PR TITLE
Implement UI memory inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ Task submission
 Real-time log and memory inspection
 
 The UI now includes a **Logs** page that polls the API for messages from each
-agent and displays them in real time.
+agent and displays them in real time. A new **Memory** page shows the latest
+memory entries reported by each agent.
 
 
 

--- a/src/Orchestrator.API/Controllers/MemoryController.cs
+++ b/src/Orchestrator.API/Controllers/MemoryController.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Mvc;
+using Shared.Messaging;
+
+namespace Orchestrator.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class MemoryController : ControllerBase
+{
+    [HttpPost("{id}")]
+    public IActionResult Send(string id, [FromBody] string entry)
+    {
+        MemoryHub.Send(id, entry);
+        return Ok();
+    }
+
+    [HttpGet("{id}")]
+    public IActionResult Receive(string id)
+    {
+        var entries = MemoryHub.Receive(id);
+        return Ok(entries);
+    }
+}

--- a/src/Orchestrator.UI/Components/Layout/NavMenu.razor
+++ b/src/Orchestrator.UI/Components/Layout/NavMenu.razor
@@ -35,6 +35,11 @@
                 <span class="bi bi-journal-text" aria-hidden="true"></span> Logs
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="memory">
+                <span class="bi bi-archive" aria-hidden="true"></span> Memory
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/src/Orchestrator.UI/Components/Pages/Memory.razor
+++ b/src/Orchestrator.UI/Components/Pages/Memory.razor
@@ -1,0 +1,83 @@
+@page "/memory"
+@using Shared.Models
+@inject HttpClient Http
+@implements IDisposable
+
+<PageTitle>Memory</PageTitle>
+
+<h1>Agent Memory</h1>
+
+<div class="mb-3">
+    <select class="form-select" value="@selectedAgentId" @onchange="OnAgentChanged">
+        <option value="">-- Select Agent --</option>
+        @foreach (var agent in agents)
+        {
+            <option value="@agent.Id">@agent.Id (@agent.Type)</option>
+        }
+    </select>
+</div>
+
+@if (!string.IsNullOrEmpty(selectedAgentId))
+{
+    <pre class="border p-2" style="height:300px; overflow-y:auto">@string.Join("\n", entries)</pre>
+}
+
+@code {
+    private List<AgentInfo> agents = new();
+    private string? selectedAgentId;
+    private readonly List<string> entries = new();
+    private CancellationTokenSource? _cts;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAgents();
+    }
+
+    private async Task LoadAgents()
+    {
+        var result = await Http.GetFromJsonAsync<List<AgentInfo>>("api/agent/list");
+        if (result != null)
+            agents = result;
+    }
+
+    private void OnAgentChanged(ChangeEventArgs e)
+    {
+        _cts?.Cancel();
+        entries.Clear();
+        selectedAgentId = e.Value?.ToString();
+        if (!string.IsNullOrEmpty(selectedAgentId))
+        {
+            _cts = new CancellationTokenSource();
+            _ = PollMemoryAsync(_cts.Token);
+        }
+    }
+
+    private async Task PollMemoryAsync(CancellationToken token)
+    {
+        var timer = new PeriodicTimer(TimeSpan.FromSeconds(2));
+        try
+        {
+            while (await timer.WaitForNextTickAsync(token))
+            {
+                await RefreshMemory();
+                await InvokeAsync(StateHasChanged);
+            }
+        }
+        catch (OperationCanceledException) { }
+    }
+
+    private async Task RefreshMemory()
+    {
+        if (string.IsNullOrEmpty(selectedAgentId))
+            return;
+
+        var result = await Http.GetFromJsonAsync<List<string>>($"api/memory/{selectedAgentId}");
+        if (result != null && result.Count > 0)
+            entries.AddRange(result);
+    }
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+    }
+}

--- a/src/Shared/Messaging/MemoryHub.cs
+++ b/src/Shared/Messaging/MemoryHub.cs
@@ -1,0 +1,25 @@
+namespace Shared.Messaging;
+
+using System.Collections.Concurrent;
+
+public static class MemoryHub
+{
+    private static readonly ConcurrentDictionary<string, ConcurrentQueue<string>> _memories = new();
+
+    public static void Send(string to, string entry)
+    {
+        var queue = _memories.GetOrAdd(to, _ => new ConcurrentQueue<string>());
+        queue.Enqueue(entry);
+    }
+
+    public static List<string> Receive(string id)
+    {
+        var result = new List<string>();
+        if (_memories.TryGetValue(id, out var queue))
+        {
+            while (queue.TryDequeue(out var entry))
+                result.Add(entry);
+        }
+        return result;
+    }
+}

--- a/tests/WorldSeed.Tests/MemoryHubTests.cs
+++ b/tests/WorldSeed.Tests/MemoryHubTests.cs
@@ -1,0 +1,16 @@
+using Shared.Messaging;
+
+namespace WorldSeed.Tests;
+
+public class MemoryHubTests
+{
+    [Fact]
+    public void SendAndReceive_ShouldDeliverEntries()
+    {
+        var id = Guid.NewGuid().ToString();
+        MemoryHub.Send(id, "first");
+        var entries = MemoryHub.Receive(id);
+        Assert.Single(entries);
+        Assert.Equal("first", entries[0]);
+    }
+}


### PR DESCRIPTION
## Summary
- add `MemoryHub` for agent memory messages
- expose memory via new API controller
- display memory in Blazor UI
- show memory nav link
- document Memory page and test `MemoryHub`

## Testing
- `dotnet test tests/WorldSeed.Tests/WorldSeed.Tests.csproj`
- `dotnet build src/Orchestrator.UI/Orchestrator.UI.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6875444df2b8832daa5d2a368de904c0