### PR TITLE
Fix seccomp error on Windows

### DIFF
--- a/src/Orchestrator.API/Services/AgentOrchestrator.cs
+++ b/src/Orchestrator.API/Services/AgentOrchestrator.cs
@@ -106,20 +106,12 @@ public class AgentOrchestrator
             Name = volumeName
         });
 
-        var securityOptions = new List<string>();
-        if (!OperatingSystem.IsWindows())
-        {
-            securityOptions.Add("apparmor=worldseed-agent");
-            securityOptions.Add($"seccomp={Path.GetFullPath("docker/profiles/seccomp-agent.json")}");
-        }
-
         var hostConfig = new HostConfig
         {
             AutoRemove = true,
             Memory = 256 * 1024 * 1024, // 256MB limit
             NanoCPUs = 1_000_000_000,   // 1 CPU
             NetworkMode = "bridge",
-            SecurityOpt = securityOptions,
             Mounts = new List<Mount>
             {
                 new()

--- a/src/Orchestrator.API/Services/AgentOrchestrator.cs
+++ b/src/Orchestrator.API/Services/AgentOrchestrator.cs
@@ -106,17 +106,20 @@ public class AgentOrchestrator
             Name = volumeName
         });
 
+        var securityOptions = new List<string>();
+        if (!OperatingSystem.IsWindows())
+        {
+            securityOptions.Add("apparmor=worldseed-agent");
+            securityOptions.Add($"seccomp={Path.GetFullPath("docker/profiles/seccomp-agent.json")}");
+        }
+
         var hostConfig = new HostConfig
         {
             AutoRemove = true,
             Memory = 256 * 1024 * 1024, // 256MB limit
             NanoCPUs = 1_000_000_000,   // 1 CPU
             NetworkMode = "bridge",
-            SecurityOpt = new List<string>
-            {
-                "apparmor=worldseed-agent",
-                $"seccomp={Path.GetFullPath("docker/profiles/seccomp-agent.json")}"
-            },
+            SecurityOpt = securityOptions,
             Mounts = new List<Mount>
             {
                 new()


### PR DESCRIPTION
## Summary
- detect Windows hosts and skip adding seccomp/app-armor options
- keeps container creation working when Docker runs on Windows

## Testing
- `dotnet test tests/WorldSeed.Tests/WorldSeed.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6875749380f8832d906bea9d6f96d21f