### PR TITLE
Fix agent logging connectivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ Set the environment variable `OPENAI_API_KEY` before starting the orchestrator
 if you want the agents to use the real OpenAI API. When this variable is not
 present the runtime falls back to a mock provider that simply echoes prompts.
 
+### Agent Connectivity
+
+Agents running in Docker containers need a reachable API endpoint in order to
+report logs and memory entries. The orchestrator now defaults to using
+`http://host.docker.internal:5000` for the `ORCHESTRATOR_URL` environment
+variable so containers can talk back to the host machine. If you run the
+orchestrator somewhere else, set `ORCHESTRATOR_URL` accordingly.
+
 ## ⚙️ Architecture
 
 ```text

--- a/scripts/devtools.ps1
+++ b/scripts/devtools.ps1
@@ -4,7 +4,12 @@ param(
 )
 
 switch ($Action) {
-    'start' { dotnet run --project ../src/Orchestrator.API }
+    'start' {
+        if (-not $env:ORCHESTRATOR_URL) {
+            $env:ORCHESTRATOR_URL = 'http://host.docker.internal:5000'
+        }
+        dotnet run --project ../src/Orchestrator.API
+    }
     'ui'    { dotnet run --project ../src/Orchestrator.UI }
     'stop'  {
         if (-not $Id) { Write-Host "Specify agent id"; break }

--- a/src/Orchestrator.API/Services/AgentOrchestrator.cs
+++ b/src/Orchestrator.API/Services/AgentOrchestrator.cs
@@ -23,7 +23,11 @@ public class AgentOrchestrator
     {
         _uow = uow;
         _useLocal = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("USE_LOCAL_AGENT"));
-        _orchestratorUrl = Environment.GetEnvironmentVariable("ORCHESTRATOR_URL") ?? "http://localhost:5000";
+        // Agents running in Docker containers cannot reach "localhost" on the host
+        // machine. Use host.docker.internal by default so agents can post logs
+        // and memory back to the API without additional configuration.
+        _orchestratorUrl = Environment.GetEnvironmentVariable("ORCHESTRATOR_URL")
+            ?? "http://host.docker.internal:5000";
         if (!_useLocal)
         {
             try


### PR DESCRIPTION
## Summary
- default orchestrator URL to `host.docker.internal` so agent containers can reach the API
- set the same URL in `devtools.ps1` if not specified
- document new Agent Connectivity section in README

## Testing
- `dotnet test tests/WorldSeed.Tests/WorldSeed.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6875775bb370832d9e40850a041f6a1b