### PR TITLE
Fix HTTP client setup and pin API port

### DIFF
--- a/src/Orchestrator.API/Program.cs
+++ b/src/Orchestrator.API/Program.cs
@@ -1,6 +1,9 @@
 using Orchestrator.API.Services;
 var builder = WebApplication.CreateBuilder(args);
 
+// Force Kestrel to listen on port 5000 for both development and production.
+builder.WebHost.UseUrls("http://localhost:5000");
+
 // Add services to the container.
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();

--- a/src/Orchestrator.UI/Program.cs
+++ b/src/Orchestrator.UI/Program.cs
@@ -6,11 +6,16 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 
-builder.Services.AddHttpClient(o =>
+// Configure a named HttpClient used by the UI components
+builder.Services.AddHttpClient("api", o =>
 {
     // The UI always communicates with the API at http://localhost:5000
     o.BaseAddress = new Uri("http://localhost:5000");
 });
+
+// Allow injecting HttpClient without specifying the name
+builder.Services.AddScoped(sp =>
+    sp.GetRequiredService<IHttpClientFactory>().CreateClient("api"));
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Summary
- fix `AddHttpClient` usage in Orchestrator.UI and expose a named client
- ensure API always listens on port `5000`

## Testing
- `dotnet build`
- `dotnet test tests/WorldSeed.Tests/WorldSeed.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68757cad15d4832d83544a20f4aa7489