### PR TITLE
Fix CORS for Blazor agent start

### DIFF
--- a/src/Orchestrator.API/Program.cs
+++ b/src/Orchestrator.API/Program.cs
@@ -10,6 +10,13 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddControllers();
 builder.Services.AddAgentOrchestrator();
+builder.Services.AddCors(o =>
+{
+    o.AddDefaultPolicy(p =>
+        p.AllowAnyOrigin()
+         .AllowAnyHeader()
+         .AllowAnyMethod());
+});
 
 var app = builder.Build();
 
@@ -19,6 +26,8 @@ if (app.Environment.IsDevelopment())
     app.UseSwagger();
     app.UseSwaggerUI();
 }
+
+app.UseCors();
 
 var summaries = new[]
 {
@@ -46,3 +55,5 @@ record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
 {
     public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
 }
+
+public partial class Program { }


### PR DESCRIPTION
## Summary
- enable CORS in Orchestrator.API so the Blazor UI can start agents
- expose Program class for integration tests

## Testing
- `dotnet test tests/WorldSeed.Tests/WorldSeed.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_687582b63748832dabf6266838d282de