### PR TITLE
Fix Docker agent connectivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,12 @@ present the runtime falls back to a mock provider that simply echoes prompts.
 ### Agent Connectivity
 
 Agents running in Docker containers need a reachable API endpoint in order to
-report logs and memory entries. The orchestrator always uses
-`http://localhost:5000` for the `ORCHESTRATOR_URL` environment variable so
-containers can talk back to the host API. If you run the orchestrator on a
-different machine, adjust `ORCHESTRATOR_URL` accordingly.
+report logs and memory entries. By default the orchestrator listens on
+`http://0.0.0.0:5000` and exposes this address through the
+`ORCHESTRATOR_URL` environment variable so containers can talk back to the
+host API. If you run the orchestrator on a different machine or network,
+update `ORCHESTRATOR_URL` to a host address accessible from the containers
+(for example `http://host.docker.internal:5000`).
 
 ## ⚙️ Architecture
 

--- a/src/Orchestrator.API/Program.cs
+++ b/src/Orchestrator.API/Program.cs
@@ -2,7 +2,8 @@ using Orchestrator.API.Services;
 var builder = WebApplication.CreateBuilder(args);
 
 // Force Kestrel to listen on port 5000 for both development and production.
-builder.WebHost.UseUrls("http://localhost:5000");
+// Listening on all interfaces allows Docker containers to reach the API.
+builder.WebHost.UseUrls("http://0.0.0.0:5000");
 
 // Add services to the container.
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle


### PR DESCRIPTION
## Summary
- listen on `0.0.0.0:5000` so containers can reach the API
- document host URL requirements for container logs

## Testing
- `dotnet test tests/WorldSeed.Tests/WorldSeed.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6875867e01cc832d93d0cf045ad17a12