### PR TITLE
Switch to API pull model

### DIFF
--- a/src/Orchestrator.API/Controllers/MemoryController.cs
+++ b/src/Orchestrator.API/Controllers/MemoryController.cs
@@ -1,5 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
-using Shared.Messaging;
+using Orchestrator.API.Services;
 
 namespace Orchestrator.API.Controllers;
 
@@ -7,17 +7,17 @@ namespace Orchestrator.API.Controllers;
 [Route("api/[controller]")]
 public class MemoryController : ControllerBase
 {
-    [HttpPost("{id}")]
-    public IActionResult Send(string id, [FromBody] string entry)
+    private readonly AgentOrchestrator _orchestrator;
+
+    public MemoryController(AgentOrchestrator orchestrator)
     {
-        MemoryHub.Send(id, entry);
-        return Ok();
+        _orchestrator = orchestrator;
     }
 
     [HttpGet("{id}")]
-    public IActionResult Receive(string id)
+    public async Task<IActionResult> Receive(string id)
     {
-        var entries = MemoryHub.Receive(id);
+        var entries = await _orchestrator.GetMemoryAsync(id);
         return Ok(entries);
     }
 }

--- a/src/Orchestrator.API/Controllers/MessageController.cs
+++ b/src/Orchestrator.API/Controllers/MessageController.cs
@@ -1,5 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
-using Shared.Messaging;
+using Orchestrator.API.Services;
 
 namespace Orchestrator.API.Controllers;
 
@@ -7,17 +7,17 @@ namespace Orchestrator.API.Controllers;
 [Route("api/[controller]")]
 public class MessageController : ControllerBase
 {
-    [HttpPost("{id}")]
-    public IActionResult Send(string id, [FromBody] string message)
+    private readonly AgentOrchestrator _orchestrator;
+
+    public MessageController(AgentOrchestrator orchestrator)
     {
-        MessageHub.Send(id, message);
-        return Ok();
+        _orchestrator = orchestrator;
     }
 
     [HttpGet("{id}")]
-    public IActionResult Receive(string id)
+    public async Task<IActionResult> Receive(string id)
     {
-        var msgs = MessageHub.Receive(id);
+        var msgs = await _orchestrator.GetMessagesAsync(id);
         return Ok(msgs);
     }
 }

--- a/tests/WorldSeed.Tests/AgentOrchestratorTests.cs
+++ b/tests/WorldSeed.Tests/AgentOrchestratorTests.cs
@@ -18,6 +18,10 @@ public class AgentOrchestratorTests
 
         Assert.Contains(uow.Agents.GetAll(), a => a.Id == id);
 
+        await Task.Delay(1500);
+        _ = await orchestrator.GetMessagesAsync(id);
+        _ = await orchestrator.GetMemoryAsync(id);
+
         await orchestrator.StopAgentAsync(id);
 
         Assert.DoesNotContain(uow.Agents.GetAll(), a => a.Id == id);


### PR DESCRIPTION
## Summary
- pull log/memory data from agents instead of having them push
- log memory entries to console in runtime
- update orchestrator service to read process or container logs
- simplify UI controllers
- adjust unit tests

## Testing
- `dotnet test tests/WorldSeed.Tests/WorldSeed.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68758932387c832d9ddcb8f1382ecf8c