### PR TITLE
Add runtime configurable OpenAI settings

### DIFF
--- a/src/Orchestrator.API/Controllers/ConfigController.cs
+++ b/src/Orchestrator.API/Controllers/ConfigController.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Mvc;
+using Orchestrator.API.Services;
+using Shared.Models;
+
+namespace Orchestrator.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ConfigController : ControllerBase
+{
+    private readonly AgentOrchestrator _orchestrator;
+
+    public ConfigController(AgentOrchestrator orchestrator)
+    {
+        _orchestrator = orchestrator;
+    }
+
+    [HttpGet("llm")]
+    public ActionResult<LLMConfig> GetLLM() => _orchestrator.GetLLMConfig();
+
+    [HttpPost("llm")]
+    public IActionResult SetLLM([FromBody] LLMConfig config)
+    {
+        _orchestrator.SetLLMConfig(config);
+        return Ok();
+    }
+}

--- a/src/Orchestrator.UI/Components/Layout/NavMenu.razor
+++ b/src/Orchestrator.UI/Components/Layout/NavMenu.razor
@@ -40,6 +40,11 @@
                 <span class="bi bi-archive" aria-hidden="true"></span> Memory
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="settings">
+                <span class="bi bi-gear" aria-hidden="true"></span> Settings
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/src/Orchestrator.UI/Components/Pages/Settings.razor
+++ b/src/Orchestrator.UI/Components/Pages/Settings.razor
@@ -1,0 +1,30 @@
+@page "/settings"
+@using Shared.Models
+@inject HttpClient Http
+
+<h1>Settings</h1>
+
+<div class="form-check mb-3">
+    <input class="form-check-input" type="checkbox" id="useOpenAI" @bind="config.UseOpenAI" />
+    <label class="form-check-label" for="useOpenAI">Use OpenAI</label>
+</div>
+<div class="mb-3">
+    <input class="form-control" placeholder="OpenAI API Key" @bind="config.ApiKey" />
+</div>
+<button class="btn btn-primary" @onclick="Save">Save</button>
+
+@code {
+    private LLMConfig config = new(false, null);
+
+    protected override async Task OnInitializedAsync()
+    {
+        var result = await Http.GetFromJsonAsync<LLMConfig>("api/config/llm");
+        if (result != null)
+            config = result;
+    }
+
+    private async Task Save()
+    {
+        await Http.PostAsJsonAsync("api/config/llm", config);
+    }
+}

--- a/src/Shared/Models/LLMConfig.cs
+++ b/src/Shared/Models/LLMConfig.cs
@@ -1,0 +1,3 @@
+namespace Shared.Models;
+
+public record LLMConfig(bool UseOpenAI, string? ApiKey);


### PR DESCRIPTION
## Summary
- introduce `LLMConfig` shared model
- add new `ConfigController` API for reading/updating LLM settings
- update `AgentOrchestrator` to store LLM config and pass token only when enabled
- create Blazor UI page to edit settings and link it in the nav menu

## Testing
- `dotnet test tests/WorldSeed.Tests/WorldSeed.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68758d4a6e7c832dbfecc9100461c46d