### PR TITLE
Fix init-only LLMConfig

### DIFF
--- a/src/Shared/Models/LLMConfig.cs
+++ b/src/Shared/Models/LLMConfig.cs
@@ -1,3 +1,27 @@
 namespace Shared.Models;
 
-public record LLMConfig(bool UseOpenAI, string? ApiKey);
+/// <summary>
+/// Configuration for language model usage.
+/// </summary>
+public record class LLMConfig
+{
+    /// <summary>
+    /// Determines if OpenAI should be used for agent requests.
+    /// </summary>
+    public bool UseOpenAI { get; set; }
+
+    /// <summary>
+    /// API key used when communicating with OpenAI services.
+    /// </summary>
+    public string? ApiKey { get; set; }
+
+    public LLMConfig()
+    {
+    }
+
+    public LLMConfig(bool useOpenAI, string? apiKey)
+    {
+        UseOpenAI = useOpenAI;
+        ApiKey = apiKey;
+    }
+}


### PR DESCRIPTION
## Summary
- allow UI to mutate `LLMConfig` by converting it to a mutable record class
- document the properties and add a convenient constructor

## Testing
- `dotnet test tests/WorldSeed.Tests/WorldSeed.Tests.csproj -v normal`

------
https://chatgpt.com/codex/tasks/task_e_6875901502f8832d87bc261cc982ef40