### PR TITLE
Enable HTTPS for API and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ present the runtime falls back to a mock provider that simply echoes prompts.
 
 Agents running in Docker containers need a reachable API endpoint in order to
 report logs and memory entries. By default the orchestrator listens on
-`http://0.0.0.0:5000` and exposes this address through the
+`https://localhost:5001` and exposes this address through the
 `ORCHESTRATOR_URL` environment variable so containers can talk back to the
 host API. If you run the orchestrator on a different machine or network,
 update `ORCHESTRATOR_URL` to a host address accessible from the containers
-(for example `http://host.docker.internal:5000`).
+(for example `https://host.docker.internal:5001`).
 
 ## ⚙️ Architecture
 
@@ -183,22 +183,22 @@ dotnet run
 Once running, start an agent with:
 
 ```bash
-curl -X POST "http://localhost:5000/api/agent/start" \
+curl -X POST "https://localhost:5001/api/agent/start" \
      -H "Content-Type: application/json" \
      -d '{"goal":"echo hello"}'
 ```
 
 ```bash
 # list running agents
-curl http://localhost:5000/api/agent/list
+curl https://localhost:5001/api/agent/list
 
 # stop an agent
-curl -X POST http://localhost:5000/api/agent/<id>/stop
+curl -X POST https://localhost:5001/api/agent/<id>/stop
 ```
 
 🌐 Access Dashboard
 
-Visit: http://localhost:5000 (Blazor Server UI)
+Visit: https://localhost:5001 (Blazor Server UI)
 
 
 ---

--- a/scripts/devtools.ps1
+++ b/scripts/devtools.ps1
@@ -6,14 +6,14 @@ param(
 switch ($Action) {
     'start' {
         if (-not $env:ORCHESTRATOR_URL) {
-            $env:ORCHESTRATOR_URL = 'http://localhost:5000'
+            $env:ORCHESTRATOR_URL = 'https://localhost:5001'
         }
         dotnet run --project ../src/Orchestrator.API
     }
     'ui'    { dotnet run --project ../src/Orchestrator.UI }
     'stop'  {
         if (-not $Id) { Write-Host "Specify agent id"; break }
-        Invoke-RestMethod -Method Post -Uri "http://localhost:5000/api/agent/$Id/stop"
+        Invoke-RestMethod -Method Post -Uri "https://localhost:5001/api/agent/$Id/stop"
     }
     default { Write-Host "Usage: devtools.ps1 [start|ui|stop <id>]" }
 }

--- a/src/Orchestrator.API/Program.cs
+++ b/src/Orchestrator.API/Program.cs
@@ -1,9 +1,10 @@
 using Orchestrator.API.Services;
 var builder = WebApplication.CreateBuilder(args);
 
-// Force Kestrel to listen on port 5000 for both development and production.
-// Listening on all interfaces allows Docker containers to reach the API.
-builder.WebHost.UseUrls("http://0.0.0.0:5000");
+// Force Kestrel to listen on https for both development and production.
+// Using localhost keeps the development certificate valid and avoids mixed
+// content issues when the UI runs under https.
+builder.WebHost.UseUrls("https://localhost:5001");
 
 // Add services to the container.
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle

--- a/src/Orchestrator.API/Services/AgentOrchestrator.cs
+++ b/src/Orchestrator.API/Services/AgentOrchestrator.cs
@@ -29,11 +29,11 @@ public class AgentOrchestrator
         _useLocal = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("USE_LOCAL_AGENT"));
         _apiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
         _useOpenAI = !string.IsNullOrWhiteSpace(_apiKey);
-        // Agents always communicate with the API over http://localhost:5000.
+        // Agents communicate with the API over https://localhost:5001.
         // Containers inherit this value through the ORCHESTRATOR_URL environment
         // variable so logs and memory are posted back to the host API.
         _orchestratorUrl = Environment.GetEnvironmentVariable("ORCHESTRATOR_URL")
-            ?? "http://localhost:5000";
+            ?? "https://localhost:5001";
         if (!_useLocal)
         {
             try

--- a/src/Orchestrator.UI/Program.cs
+++ b/src/Orchestrator.UI/Program.cs
@@ -9,8 +9,8 @@ builder.Services.AddRazorComponents()
 // Configure a named HttpClient used by the UI components
 builder.Services.AddHttpClient("api", o =>
 {
-    // The UI always communicates with the API at http://localhost:5000
-    o.BaseAddress = new Uri("http://localhost:5000");
+    // The UI always communicates with the API over https
+    o.BaseAddress = new Uri("https://localhost:5001");
 });
 
 // Allow injecting HttpClient without specifying the name


### PR DESCRIPTION
## Summary
- serve Orchestrator.API over HTTPS by default
- update AgentOrchestrator to use HTTPS URL
- adjust UI HttpClient and dev tools script for HTTPS
- update documentation for new endpoints

## Testing
- `dotnet test tests/WorldSeed.Tests/WorldSeed.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_687593fc8bd0832da0ac36f8b912170e