### PR TITLE
Fix Start Agent button not triggering

### DIFF
--- a/src/Orchestrator.UI/Components/Pages/Agents.razor
+++ b/src/Orchestrator.UI/Components/Pages/Agents.razor
@@ -1,4 +1,5 @@
 @page "/agents"
+@rendermode InteractiveServer
 @using Shared.Models
 @inject HttpClient Http
 

--- a/src/Orchestrator.UI/Components/Pages/Settings.razor
+++ b/src/Orchestrator.UI/Components/Pages/Settings.razor
@@ -1,4 +1,5 @@
 @page "/settings"
+@rendermode InteractiveServer
 @using Shared.Models
 @inject HttpClient Http
 


### PR DESCRIPTION
## Summary
- enable server interactivity for the Agents page
- enable server interactivity for the Settings page

## Testing
- `dotnet test WorldSeed.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68759acc60c4832dba9887ca035bc33e