### PR TITLE
Enable configurable agent loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Set the environment variable `OPENAI_API_KEY` before starting the orchestrator
 if you want the agents to use the real OpenAI API. When this variable is not
 present the runtime falls back to a mock provider that simply echoes prompts.
 
+### Agent Loop Count
+
+The agent's reasoning loop iteration count can be customized via the `LOOP_COUNT`
+environment variable. When omitted the agent will iterate three times before
+stopping.
+
 ### Agent Connectivity
 
 Agents running in Docker containers need a reachable API endpoint in order to
@@ -185,7 +191,7 @@ Once running, start an agent with:
 ```bash
 curl -X POST "http://localhost:5000/api/agent/start" \
      -H "Content-Type: application/json" \
-     -d '{"goal":"echo hello"}'
+     -d '{"goal":"echo hello","loops":5}'
 ```
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ present the runtime falls back to a mock provider that simply echoes prompts.
 
 ### Agent Loop Count
 
-The agent's reasoning loop iteration count can be customized via the `LOOP_COUNT`
-environment variable. When omitted the agent will iterate three times before
-stopping.
+The number of iterations an agent performs can be specified by setting the
+`LOOP_COUNT` environment variable or by passing a `loops` value when starting an
+agent through the API. The agent will run until either it receives the `DONE`
+signal from the LLM or the configured loop count is reached.
 
 ### Agent Connectivity
 

--- a/src/Agent.Runtime/Program.cs
+++ b/src/Agent.Runtime/Program.cs
@@ -53,6 +53,12 @@ async Task RunAsync(string[] args)
     for (var i = 0; i < loops; i++)
     {
         var action = await PlanNextAction(goal, memory);
+        if (string.Equals(action, "done", StringComparison.OrdinalIgnoreCase))
+        {
+            SendLog("Planner indicated completion.");
+            break;
+        }
+
         var parts = action.Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
         if (parts.Length == 0)
         {
@@ -87,7 +93,10 @@ async Task<string> PlanNextAction(string currentGoal, List<string> memory)
 {
     var tools = string.Join(", ", ToolRegistry.GetToolNames());
     var mem = memory.Count == 0 ? "none" : string.Join("; ", memory);
-    var prompt = $"Goal: {currentGoal}\nMemory: {mem}\nAvailable tools: {tools}\nRespond with '<tool> <input>'";
+    var prompt = $"You are an autonomous agent. Current goal: '{currentGoal}'." +
+        $" Past actions: {mem}. Available tools: {tools}." +
+        " Choose the next tool and input in the format '<tool> <input>'." +
+        " Reply with 'DONE' if the goal is complete.";
     var result = await llmProvider.CompleteAsync(prompt);
     return result.Trim();
 }

--- a/src/Agent.Runtime/Tools/ToolRegistry.cs
+++ b/src/Agent.Runtime/Tools/ToolRegistry.cs
@@ -24,4 +24,6 @@ public static class ToolRegistry
         _tools.TryGetValue(name, out var tool);
         return tool;
     }
+
+    public static IEnumerable<string> GetToolNames() => _tools.Keys;
 }

--- a/src/Orchestrator.API/Controllers/AgentController.cs
+++ b/src/Orchestrator.API/Controllers/AgentController.cs
@@ -35,7 +35,7 @@ public class AgentController : ControllerBase
     [HttpPost("start")]
     public async Task<IActionResult> Start([FromBody] StartAgentRequest request)
     {
-        var id = await _orchestrator.StartAgentAsync(request.Goal, request.Type);
+        var id = await _orchestrator.StartAgentAsync(request.Goal, request.Type, request.Loops);
         return Ok(new { id });
     }
 

--- a/src/Orchestrator.API/Services/AgentOrchestrator.cs
+++ b/src/Orchestrator.API/Services/AgentOrchestrator.cs
@@ -57,7 +57,7 @@ public class AgentOrchestrator
         _apiKey = config.ApiKey;
     }
 
-    public async Task<string> StartAgentAsync(string goal, AgentType type = AgentType.Default)
+    public async Task<string> StartAgentAsync(string goal, AgentType type = AgentType.Default, int loops = 3)
     {
         var apiKey = _useOpenAI ? _apiKey : null;
 
@@ -85,6 +85,7 @@ public class AgentOrchestrator
 
             psi.Environment["AGENT_ID"] = id;
             psi.Environment["ORCHESTRATOR_URL"] = _orchestratorUrl;
+            psi.Environment["LOOP_COUNT"] = loops.ToString();
 
             var proc = new Process { StartInfo = psi, EnableRaisingEvents = true };
             var logList = new List<string>();
@@ -120,7 +121,8 @@ public class AgentOrchestrator
         {
             $"GOAL={goal}",
             $"AGENT_ID={id}",
-            $"ORCHESTRATOR_URL={_orchestratorUrl}"
+            $"ORCHESTRATOR_URL={_orchestratorUrl}",
+            $"LOOP_COUNT={loops}"
         };
 
         if (!string.IsNullOrWhiteSpace(apiKey))

--- a/src/Orchestrator.UI/Components/Pages/Agents.razor
+++ b/src/Orchestrator.UI/Components/Pages/Agents.razor
@@ -11,6 +11,9 @@
     <input class="form-control" placeholder="Goal" @bind="goal" />
 </div>
 <div class="mb-3">
+    <input type="number" class="form-control" placeholder="Loops" @bind="loops" />
+</div>
+<div class="mb-3">
     <select class="form-select" @bind="selectedType">
         @foreach (var type in Enum.GetValues<AgentType>())
         {
@@ -33,6 +36,7 @@
 @code {
     private string goal = string.Empty;
     private AgentType selectedType = AgentType.Default;
+    private int loops = 3;
     private List<AgentInfo> agents = new();
 
     protected override async Task OnInitializedAsync()
@@ -49,12 +53,13 @@
 
     private async Task StartAgent()
     {
-        var request = new StartAgentRequest(goal, selectedType);
+        var request = new StartAgentRequest(goal, selectedType, loops);
         var response = await Http.PostAsJsonAsync("api/agent/start", request);
         if (response.IsSuccessStatusCode)
         {
             await LoadAgents();
             goal = string.Empty;
+            loops = 3;
         }
     }
 

--- a/src/Shared/Models/StartAgentRequest.cs
+++ b/src/Shared/Models/StartAgentRequest.cs
@@ -1,3 +1,3 @@
 namespace Shared.Models;
 
-public record StartAgentRequest(string Goal, AgentType Type = AgentType.Default);
+public record StartAgentRequest(string Goal, AgentType Type = AgentType.Default, int Loops = 3);


### PR DESCRIPTION
## Summary
- allow customizing loop count via `LOOP_COUNT`
- expose loops in StartAgentRequest
- pass loops from orchestrator to runtime
- have agent plan actions using LLM each iteration
- document loops in README
- add loops field to Blazor UI when starting an agent

## Testing
- `dotnet build WorldSeed.sln`
- `dotnet test tests/WorldSeed.Tests/WorldSeed.Tests.csproj --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_68762177af88832d8e3e8e566ffdc876