### PR TITLE
Default to gpt-4.1-nano

### DIFF
--- a/src/Shared/LLM/OpenAIProvider.cs
+++ b/src/Shared/LLM/OpenAIProvider.cs
@@ -8,7 +8,7 @@ public class OpenAIProvider : ILLMProvider
     private readonly OpenAIAPI _api;
     private readonly string _model;
 
-    public OpenAIProvider(string apiKey, string model = "gpt-3.5-turbo")
+    public OpenAIProvider(string apiKey, string model = "gpt-4.1-nano")
     {
         _api = new OpenAIAPI(apiKey);
         _model = model;


### PR DESCRIPTION
## Summary
- use gpt-4.1-nano by default for the OpenAI provider

## Testing
- `dotnet test tests/WorldSeed.Tests/WorldSeed.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68762ff7ebf4832db873465e0b29df60