### PR TITLE
Default to gpt-4.1-nano

### DIFF
--- a/src/Agent.Runtime/AgentRunner.cs
+++ b/src/Agent.Runtime/AgentRunner.cs
@@ -1,0 +1,90 @@
+using Agent.Runtime.Tools;
+using Shared.LLM;
+
+namespace Agent.Runtime;
+
+public static class AgentRunner
+{
+    public static async Task<List<string>> RunAsync(string goal, ILLMProvider llmProvider, int loops = 3, Action<string>? log = null)
+    {
+        log ??= Console.WriteLine;
+        ToolRegistry.Initialize(llmProvider);
+        var memory = new List<string>();
+
+        for (var i = 0; i < loops; i++)
+        {
+            log($"--- Loop {i + 1} of {loops} ---");
+
+            var action = await PlanNextAction(goal, memory, llmProvider, log);
+            log($"Planner returned action: '{action}'");
+
+            if (string.Equals(action, "done", StringComparison.OrdinalIgnoreCase))
+            {
+                log("Planner indicated completion.");
+                break;
+            }
+
+            var parts = action.Split(new[] { ' ', ':' }, 2, StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length == 0)
+            {
+                log("Planner returned no action.");
+                break;
+            }
+
+            var toolName = parts[0];
+            var toolInput = parts.Length > 1 ? parts[1] : string.Empty;
+
+            var tool = ToolRegistry.Get(toolName);
+            string result;
+            if (tool is null)
+            {
+                log($"Tool '{toolName}' not found. Falling back to chat.");
+                var chat = ToolRegistry.Get("chat");
+                if (chat is null)
+                {
+                    log("Chat tool is not registered. Skipping this step.");
+                    memory.Add($"unknown {toolName} -> no execution");
+                    continue;
+                }
+
+                result = await chat.ExecuteAsync(action);
+                memory.Add($"unknown {toolName} -> chat {action} => {result}");
+                log($"MEMORY: unknown {toolName} -> chat {action} => {result}");
+            }
+            else
+            {
+                result = await tool.ExecuteAsync(toolInput);
+                memory.Add($"{toolName} {toolInput} => {result}");
+                log($"MEMORY: {toolName} {toolInput} => {result}");
+            }
+
+            log(result);
+            goal = result;
+        }
+
+        log("--- Final Memory ---");
+        foreach (var entry in memory)
+            log($"MEMORY: {entry}");
+
+        return memory;
+    }
+
+    private static async Task<string> PlanNextAction(string currentGoal, List<string> memory, ILLMProvider llmProvider, Action<string> log)
+    {
+        var tools = string.Join(", ", ToolRegistry.GetToolNames());
+        var mem = memory.Count == 0 ? "none" : string.Join("; ", memory);
+        var prompt =
+            $"You are an autonomous agent. Current goal: '{currentGoal}'." +
+            $" Past actions: {mem}." +
+            $" Available tools: {tools}." +
+            " Respond ONLY with '<tool> <input>' using one of the tool names above." +
+            " If unsure which tool fits, use 'chat' with a helpful question." +
+            " Reply with 'DONE' when the goal is complete.";
+        log($"PlanNextAction prompt: {prompt}");
+        var result = await llmProvider.CompleteAsync(prompt);
+        log($"PlanNextAction result: {result}");
+
+        var line = result.Split('\n')[0].Trim().Trim('"', '.', '!');
+        return line;
+    }
+}

--- a/src/Agent.Runtime/AgentRunner.cs
+++ b/src/Agent.Runtime/AgentRunner.cs
@@ -25,6 +25,7 @@ public static class AgentRunner
             }
 
             var parts = action.Split(new[] { ' ', ':' }, 2, StringSplitOptions.RemoveEmptyEntries);
+            log($"Parsed parts: {string.Join(", ", parts)}");
             if (parts.Length == 0)
             {
                 log("Planner returned no action.");
@@ -33,6 +34,7 @@ public static class AgentRunner
 
             var toolName = parts[0];
             var toolInput = parts.Length > 1 ? parts[1] : string.Empty;
+            log($"Parsed toolName: '{toolName}' input: '{toolInput}'");
 
             var tool = ToolRegistry.Get(toolName);
             string result;
@@ -85,6 +87,7 @@ public static class AgentRunner
         log($"PlanNextAction result: {result}");
 
         var line = result.Split('\n')[0].Trim().Trim('"', '.', '!');
+        log($"PlanNextAction parsed line: {line}");
         return line;
     }
 }

--- a/src/Agent.Runtime/AgentRunner.cs
+++ b/src/Agent.Runtime/AgentRunner.cs
@@ -35,6 +35,7 @@ public static class AgentRunner
             var toolName = parts[0];
             var toolInput = parts.Length > 1 ? parts[1] : string.Empty;
             log($"Parsed toolName: '{toolName}' input: '{toolInput}'");
+            log($"Looking up tool '{toolName}' among: {string.Join(", ", ToolRegistry.GetToolNames())}");
 
             var tool = ToolRegistry.Get(toolName);
             string result;

--- a/src/Shared/LLM/OpenAIProvider.cs
+++ b/src/Shared/LLM/OpenAIProvider.cs
@@ -8,7 +8,7 @@ public class OpenAIProvider : ILLMProvider
     private readonly OpenAIAPI _api;
     private readonly string _model;
 
-    public OpenAIProvider(string apiKey, string model = "gpt-3.5-turbo")
+    public OpenAIProvider(string apiKey, string model = "gpt-4.1-nano")
     {
         _api = new OpenAIAPI(apiKey);
         _model = model;

--- a/tests/WorldSeed.Tests/AgentRunnerTests.cs
+++ b/tests/WorldSeed.Tests/AgentRunnerTests.cs
@@ -1,0 +1,44 @@
+using Agent.Runtime;
+using Shared.LLM;
+
+namespace WorldSeed.Tests;
+
+public class AgentRunnerTests
+{
+    [Fact]
+    public async Task RunAsync_LoopsTwice_ReturnsCapitals()
+    {
+        var provider = new SequenceLLMProvider(new[]
+        {
+            "chat What is the capital of France?",
+            "The capital of France is Paris.",
+            "chat What is the capital of Belgium?",
+            "The capital of Belgium is Brussels."
+        });
+
+        var memory = await AgentRunner.RunAsync(
+            "What is the capital of france and belgium? reply in 2 loops.",
+            provider,
+            2,
+            _ => { });
+
+        Assert.Equal(2, memory.Count);
+        Assert.Equal("chat What is the capital of France? => The capital of France is Paris.", memory[0]);
+        Assert.Equal("chat What is the capital of Belgium? => The capital of Belgium is Brussels.", memory[1]);
+    }
+
+    private class SequenceLLMProvider : ILLMProvider
+    {
+        private readonly Queue<string> _responses;
+
+        public SequenceLLMProvider(IEnumerable<string> responses)
+        {
+            _responses = new Queue<string>(responses);
+        }
+
+        public Task<string> CompleteAsync(string prompt, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(_responses.Count > 0 ? _responses.Dequeue() : string.Empty);
+        }
+    }
+}

--- a/tests/WorldSeed.Tests/AgentRunnerTests.cs
+++ b/tests/WorldSeed.Tests/AgentRunnerTests.cs
@@ -27,6 +27,22 @@ public class AgentRunnerTests
         Assert.Equal("chat What is the capital of Belgium? => The capital of Belgium is Brussels.", memory[1]);
     }
 
+    [Fact]
+    public async Task RunAsync_MissingTool_LogsAvailableTools()
+    {
+        var provider = new SequenceLLMProvider(new[]
+        {
+            "foo hello",
+            "fallback"
+        });
+
+        var logs = new List<string>();
+        await AgentRunner.RunAsync("test", provider, 1, logs.Add);
+
+        Assert.Contains(logs, l => l.Contains("Looking up tool 'foo'"));
+        Assert.Contains(logs, l => l.Contains("Tool 'foo' not found"));
+    }
+
     private class SequenceLLMProvider : ILLMProvider
     {
         private readonly Queue<string> _responses;


### PR DESCRIPTION
## Summary
- use gpt-4.1-nano by default for the OpenAI provider
- extract agent loop logic into a reusable `AgentRunner`
- test `AgentRunner` so it loops twice and returns capitals for France and Belgium

## Testing
- `dotnet test tests/WorldSeed.Tests/WorldSeed.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68762ff7ebf4832db873465e0b29df60