### PR TITLE
Show full logs each poll

### DIFF
--- a/src/Orchestrator.API/Controllers/MessageController.cs
+++ b/src/Orchestrator.API/Controllers/MessageController.cs
@@ -20,4 +20,11 @@ public class MessageController : ControllerBase
         var msgs = await _orchestrator.GetMessagesAsync(id);
         return Ok(msgs);
     }
+
+    [HttpGet("{id}/all")]
+    public async Task<IActionResult> ReceiveAll(string id)
+    {
+        var msgs = await _orchestrator.GetAllMessagesAsync(id);
+        return Ok(msgs);
+    }
 }

--- a/src/Orchestrator.UI/Components/Pages/Logs.razor
+++ b/src/Orchestrator.UI/Components/Pages/Logs.razor
@@ -72,9 +72,12 @@
         if (string.IsNullOrEmpty(selectedAgentId))
             return;
 
-        var result = await Http.GetFromJsonAsync<List<string>>($"api/message/{selectedAgentId}");
-        if (result != null && result.Count > 0)
+        var result = await Http.GetFromJsonAsync<List<string>>($"api/message/{selectedAgentId}/all");
+        if (result != null)
+        {
+            messages.Clear();
             messages.AddRange(result);
+        }
     }
 
     public void Dispose()


### PR DESCRIPTION
## Summary
- expose endpoint to return all logs (`/{id}/all`)
- add `GetAllMessagesAsync` to orchestrator and helper to fetch complete log
- update `Logs.razor` to request full log each cycle

## Testing
- `dotnet test tests/WorldSeed.Tests/WorldSeed.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_687637acf448832d91186b1ca424860b