### PR TITLE
Enable unlimited agent loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ The number of iterations an agent performs can be specified by setting the
 `LOOP_COUNT` environment variable or by passing a `loops` value when starting an
 agent through the API. The agent will run until either it receives the `DONE`
 signal from the LLM or the configured loop count is reached. Specify `0` or any
-negative value to run indefinitely until the LLM returns `DONE`.
+negative value to run indefinitely until the LLM returns `DONE`. On each
+iteration the agent sends its full history to the LLM provider so actions are
+planned with complete context.
 
 ### Agent Connectivity
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ present the runtime falls back to a mock provider that simply echoes prompts.
 The number of iterations an agent performs can be specified by setting the
 `LOOP_COUNT` environment variable or by passing a `loops` value when starting an
 agent through the API. The agent will run until either it receives the `DONE`
-signal from the LLM or the configured loop count is reached.
+signal from the LLM or the configured loop count is reached. Specify `0` or any
+negative value to run indefinitely until the LLM returns `DONE`.
 
 ### Agent Connectivity
 

--- a/src/Agent.Runtime/AgentRunner.cs
+++ b/src/Agent.Runtime/AgentRunner.cs
@@ -94,6 +94,10 @@ public static class AgentRunner
 
         var line = result.Split('\n')[0].Trim().Trim('"', '.', '!');
         log($"PlanNextAction parsed line: {line}");
+
+        if (result.Contains("DONE", StringComparison.OrdinalIgnoreCase))
+            return "done";
+
         return line;
     }
 }

--- a/src/Agent.Runtime/AgentRunner.cs
+++ b/src/Agent.Runtime/AgentRunner.cs
@@ -8,8 +8,8 @@ public static class AgentRunner
     public static async Task<List<string>> RunAsync(string goal, ILLMProvider llmProvider, int loops = 3, Action<string>? log = null)
     {
         log ??= Console.WriteLine;
-        ToolRegistry.Initialize(llmProvider);
         var memory = new List<string>();
+        ToolRegistry.Initialize(llmProvider, memory);
 
         var i = 0;
         while (loops <= 0 || i < loops)

--- a/src/Agent.Runtime/AgentRunner.cs
+++ b/src/Agent.Runtime/AgentRunner.cs
@@ -96,7 +96,10 @@ public static class AgentRunner
         log($"PlanNextAction parsed line: {line}");
 
         if (result.Contains("DONE", StringComparison.OrdinalIgnoreCase))
+        {
+            log("LLM signaled DONE");
             return "done";
+        }
 
         return line;
     }

--- a/src/Agent.Runtime/AgentRunner.cs
+++ b/src/Agent.Runtime/AgentRunner.cs
@@ -11,9 +11,12 @@ public static class AgentRunner
         ToolRegistry.Initialize(llmProvider);
         var memory = new List<string>();
 
-        for (var i = 0; i < loops; i++)
+        var i = 0;
+        while (loops <= 0 || i < loops)
         {
-            var loopMessage = $"--- Starting loop {i + 1} of {loops} ---";
+            var loopMessage = loops <= 0
+                ? $"--- Starting loop {i + 1} ---"
+                : $"--- Starting loop {i + 1} of {loops} ---";
             log(loopMessage);
 
             var action = await PlanNextAction(goal, memory, llmProvider, log);
@@ -64,6 +67,7 @@ public static class AgentRunner
 
             log(result);
             goal = result;
+            i++;
         }
 
         log("--- Final Memory ---");

--- a/src/Agent.Runtime/Program.cs
+++ b/src/Agent.Runtime/Program.cs
@@ -38,7 +38,7 @@ async Task RunAsync(string[] args)
 
     var loops = 3;
     if (int.TryParse(Environment.GetEnvironmentVariable("LOOP_COUNT"), out var parsed))
-        loops = parsed;
+        loops = parsed; // 0 or negative = unlimited loops
 
     await AgentRunner.RunAsync(goal, llmProvider, loops, SendLog);
 }

--- a/src/Agent.Runtime/Tools/ChatTool.cs
+++ b/src/Agent.Runtime/Tools/ChatTool.cs
@@ -7,14 +7,18 @@ public class ChatTool : ITool
     public string Name => "chat";
 
     private readonly ILLMProvider _provider;
+    private readonly List<string> _memory;
 
-    public ChatTool(ILLMProvider provider)
+    public ChatTool(ILLMProvider provider, List<string> memory)
     {
         _provider = provider;
+        _memory = memory;
     }
 
     public async Task<string> ExecuteAsync(string input)
     {
-        return await _provider.CompleteAsync(input);
+        var history = _memory.Count == 0 ? "none" : string.Join("; ", _memory);
+        var prompt = $"History: {history}. User: {input}";
+        return await _provider.CompleteAsync(prompt);
     }
 }

--- a/src/Agent.Runtime/Tools/ToolRegistry.cs
+++ b/src/Agent.Runtime/Tools/ToolRegistry.cs
@@ -8,11 +8,11 @@ public static class ToolRegistry
 {
     private static readonly ConcurrentDictionary<string, ITool> _tools = new(StringComparer.OrdinalIgnoreCase);
 
-    public static void Initialize(ILLMProvider llmProvider)
+    public static void Initialize(ILLMProvider llmProvider, List<string> memory)
     {
         // Register built-in tools
         Register(new EchoTool());
-        Register(new ChatTool(llmProvider));
+        Register(new ChatTool(llmProvider, memory));
         Register(new ListTool(llmProvider));
     }
 

--- a/src/Agent.Runtime/Tools/ToolRegistry.cs
+++ b/src/Agent.Runtime/Tools/ToolRegistry.cs
@@ -10,6 +10,7 @@ public static class ToolRegistry
 
     public static void Initialize(ILLMProvider llmProvider, List<string> memory)
     {
+        _tools.Clear();
         // Register built-in tools
         Register(new EchoTool());
         Register(new ChatTool(llmProvider, memory));

--- a/tests/WorldSeed.Tests/AgentRunnerTests.cs
+++ b/tests/WorldSeed.Tests/AgentRunnerTests.cs
@@ -43,6 +43,25 @@ public class AgentRunnerTests
         Assert.Contains(logs, l => l.Contains("Tool 'foo' not found"));
     }
 
+    [Fact]
+    public async Task RunAsync_ZeroLoops_RunsUntilDone()
+    {
+        var provider = new SequenceLLMProvider(new[]
+        {
+            "chat step one",
+            "result one",
+            "chat step two",
+            "result two",
+            "done"
+        });
+
+        var memory = await AgentRunner.RunAsync("test", provider, 0, _ => { });
+
+        Assert.Equal(2, memory.Count);
+        Assert.Equal("chat step one => result one", memory[0]);
+        Assert.Equal("chat step two => result two", memory[1]);
+    }
+
     private class SequenceLLMProvider : ILLMProvider
     {
         private readonly Queue<string> _responses;

--- a/tests/WorldSeed.Tests/AgentRunnerTests.cs
+++ b/tests/WorldSeed.Tests/AgentRunnerTests.cs
@@ -78,6 +78,17 @@ public class AgentRunnerTests
         Assert.Contains("chat hi => pong", provider.Prompts[2]);
     }
 
+    [Fact]
+    public async Task RunAsync_LogsWhenDone()
+    {
+        var provider = new SequenceLLMProvider(new[] { "done" });
+        var logs = new List<string>();
+
+        await AgentRunner.RunAsync("test", provider, 0, logs.Add);
+
+        Assert.Contains(logs, l => l.Contains("LLM signaled DONE"));
+    }
+
     private class SequenceLLMProvider : ILLMProvider
     {
         private readonly Queue<string> _responses;

--- a/tests/WorldSeed.Tests/AssemblyInfo.cs
+++ b/tests/WorldSeed.Tests/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+using Xunit;
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/WorldSeed.Tests/ToolRegistryTests.cs
+++ b/tests/WorldSeed.Tests/ToolRegistryTests.cs
@@ -8,7 +8,7 @@ public class ToolRegistryTests
     [Fact]
     public void Initialize_RegistersBuiltInTools()
     {
-        ToolRegistry.Initialize(new MockOpenAIProvider());
+        ToolRegistry.Initialize(new MockOpenAIProvider(), new List<string>());
 
         Assert.NotNull(ToolRegistry.Get("echo"));
         Assert.NotNull(ToolRegistry.Get("chat"));
@@ -23,7 +23,7 @@ public class ToolRegistryTests
     [Fact]
     public void Register_CustomTool_IsRetrievable()
     {
-        ToolRegistry.Initialize(new MockOpenAIProvider());
+        ToolRegistry.Initialize(new MockOpenAIProvider(), new List<string>());
         var custom = new CustomTool();
         ToolRegistry.Register(custom);
 


### PR DESCRIPTION
## Summary
- allow agents to run indefinitely when `LOOP_COUNT` is 0 or negative
- update loop logic in `AgentRunner`
- note unlimited loop behavior in README
- add a unit test for unlimited loops

## Testing
- `dotnet test tests/WorldSeed.Tests/WorldSeed.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6876431e5de8832d8061cb6a45c7cf41