### PR TITLE
Improve agent action parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ negative value to run indefinitely until the LLM returns `DONE`. On each
 iteration the agent sends its full history to the LLM provider so actions are
 planned with complete context.
 
+### Expected LLM Response Format
+
+The planner parses only the first line of the LLM response and expects the
+format `<tool> <input>` or the single word `DONE`. If the returned tool name does
+not match one of the registered tools the agent falls back to the `chat` tool.
+Ensure your language model is prompted to follow this format precisely. When
+using other models or custom prompts, verify that the first word corresponds to
+a valid tool name such as `chat`, `echo`, or `list`.
+
 ### Agent Connectivity
 
 Agents running in Docker containers need a reachable API endpoint in order to

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ Ensure your language model is prompted to follow this format precisely. When
 using other models or custom prompts, verify that the first word corresponds to
 a valid tool name such as `chat`, `echo`, or `list`.
 
+When an unknown tool is encountered the agent reuses the `chat` tool to handle
+the response. Such fallbacks do not count toward the configured loop limit, but
+after three consecutive unknown responses the agent stops to avoid an infinite
+loop.
+
 ### Agent Connectivity
 
 Agents running in Docker containers need a reachable API endpoint in order to

--- a/tests/WorldSeed.Tests/AgentRunnerTests.cs
+++ b/tests/WorldSeed.Tests/AgentRunnerTests.cs
@@ -39,8 +39,7 @@ public class AgentRunnerTests
         var logs = new List<string>();
         await AgentRunner.RunAsync("test", provider, 1, logs.Add);
 
-        Assert.Contains(logs, l => l.Contains("Looking up tool 'foo'"));
-        Assert.Contains(logs, l => l.Contains("Tool 'foo' not found"));
+        Assert.Contains(logs, l => l.Contains("Unrecognized tool 'foo'"));
     }
 
     [Fact]

--- a/tests/WorldSeed.Tests/AgentRunnerTests.cs
+++ b/tests/WorldSeed.Tests/AgentRunnerTests.cs
@@ -43,6 +43,22 @@ public class AgentRunnerTests
     }
 
     [Fact]
+    public async Task RunAsync_UnrecognizedTool_DoesNotCountLoop()
+    {
+        var provider = new SequenceLLMProvider(new[]
+        {
+            "foo greet",
+            "chat hi",
+            "pong"
+        });
+
+        var memory = await AgentRunner.RunAsync("test", provider, 1, _ => { });
+
+        Assert.Single(memory);
+        Assert.Contains("chat hi => pong", memory[0]);
+    }
+
+    [Fact]
     public async Task RunAsync_ZeroLoops_RunsUntilDone()
     {
         var provider = new SequenceLLMProvider(new[]


### PR DESCRIPTION
## Summary
- retry plan prompts when tool name is unrecognized
- document expected LLM response format
- update logging test for new behaviour

## Testing
- `dotnet test tests/WorldSeed.Tests/WorldSeed.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68766a720210832dbf2fbbeeeb67937f