### PR TITLE
Fix Dockerfile path for Agent.Runtime publish output

### DIFF
--- a/docker/agent.Dockerfile
+++ b/docker/agent.Dockerfile
@@ -1,4 +1,4 @@
 FROM mcr.microsoft.com/dotnet/runtime:8.0
 WORKDIR /app
-COPY ./Agent.Runtime/bin/Release/net8.0/ ./
+COPY ./src/Agent.Runtime/bin/Release/net8.0/publish/ ./
 ENTRYPOINT ["dotnet", "Agent.Runtime.dll"]


### PR DESCRIPTION
## Summary
- correct copy path in `docker/agent.Dockerfile`
- publish Agent.Runtime in Release configuration

## Testing
- `dotnet publish src/Agent.Runtime -c Release -o ./src/Agent.Runtime/bin/Release/net8.0/publish`
- `dotnet test WorldSeed.sln`
- `dockerd` *(fails: operation not permitted)*

------
https://chatgpt.com/codex/tasks/task_e_6876799c87d0832db8d326fadaaa7292