### PR TITLE
Add automatic Docker image build

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -4,6 +4,7 @@
   </PropertyGroup>
 
   <Target Name="BuildWorldseedAgentImage" AfterTargets="Build" Condition="'$(MSBuildProjectName)' == 'Orchestrator.API'">
+    <Exec Command="dotnet build $(RepoRoot)src/Agent.Runtime/Agent.Runtime.csproj -c Release" />
     <Exec Command="docker --version" IgnoreExitCode="true" LogStandardErrorAsError="false">
       <Output TaskParameter="ExitCode" PropertyName="DockerAvailable" />
     </Exec>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,13 @@
+<Project>
+  <PropertyGroup>
+    <RepoRoot>$(MSBuildThisFileDirectory)</RepoRoot>
+  </PropertyGroup>
+
+  <Target Name="BuildWorldseedAgentImage" AfterTargets="Build" Condition="'$(MSBuildProjectName)' == 'Orchestrator.API'">
+    <Exec Command="docker --version" IgnoreExitCode="true" LogStandardErrorAsError="false">
+      <Output TaskParameter="ExitCode" PropertyName="DockerAvailable" />
+    </Exec>
+    <Message Text="Building Docker image worldseed-agent:latest" Importance="high" Condition="'$(DockerAvailable)' == '0'" />
+    <Exec Condition="'$(DockerAvailable)' == '0'" Command="docker build -f $(RepoRoot)docker/agent.Dockerfile -t worldseed-agent:latest $(RepoRoot)" />
+  </Target>
+</Project>

--- a/README.md
+++ b/README.md
@@ -204,7 +204,9 @@ dotnet build ./src
 
 🐳 Build Agent Image
 
-docker build -f ./docker/agent.Dockerfile -t myagent:latest .
+docker build -f ./docker/agent.Dockerfile -t worldseed-agent:latest .
+
+Building the solution automatically rebuilds this image to ensure it stays up-to-date.
 
 ▶️ Run Orchestrator Locally
 
@@ -249,7 +251,7 @@ docker run -d --rm \
   --name agent-{id} \
   --security-opt seccomp=./docker/profiles/seccomp-agent.json \
   --security-opt apparmor=worldseed-agent \
-  myagent:latest --goal="..."
+  worldseed-agent:latest --goal="..."
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ dotnet build ./src
 docker build -f ./docker/agent.Dockerfile -t worldseed-agent:latest .
 
 Building the solution automatically rebuilds this image to ensure it stays up-to-date.
+The build also compiles the Agent.Runtime project in Release mode so the Docker
+context contains the latest binaries.
 
 ▶️ Run Orchestrator Locally
 

--- a/docker/agent.Dockerfile
+++ b/docker/agent.Dockerfile
@@ -1,4 +1,4 @@
 FROM mcr.microsoft.com/dotnet/runtime:8.0
 WORKDIR /app
-COPY ./Agent.Runtime/bin/Release/net8.0/ ./
+COPY ./src/Agent.Runtime/bin/Release/net8.0/ ./
 ENTRYPOINT ["dotnet", "Agent.Runtime.dll"]


### PR DESCRIPTION
## Summary
- rebuild `worldseed-agent:latest` Docker image after Orchestrator.API project builds
- update docs with new image name and note about auto build

## Testing
- `dotnet test tests/WorldSeed.Tests/WorldSeed.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68767c0b478c832d93025a5cc33198e1