### PR TITLE
Fix goal persistence in agent loop

### DIFF
--- a/src/Agent.Runtime/AgentRunner.cs
+++ b/src/Agent.Runtime/AgentRunner.cs
@@ -132,7 +132,10 @@ public static class AgentRunner
         var tools = string.Join(", ", ToolRegistry.GetToolNames());
         var mem = memory.Count == 0 ? "none" : string.Join("; ", memory);
         var prompt = $@"You are an autonomous agent working toward the goal: '{goal}'.
-Loops remaining (including this one): {loopsLeft}.
+Loops remaining (including this one): {loopsLeft}.";
+        if (loopsLeft != "unlimited")
+            prompt += " You must complete the goal by the final loop.";
+        prompt += $@"
 Last result: '{context}'.
 Past actions: {mem}.
 Available tools: {tools}

--- a/src/Agent.Runtime/AgentRunner.cs
+++ b/src/Agent.Runtime/AgentRunner.cs
@@ -14,6 +14,7 @@ public static class AgentRunner
 
         var i = 0;
         var unknownCount = 0;
+        var nextTask = goal;
         while (loops <= 0 || i < loops)
         {
             var loopMessage = loops <= 0
@@ -21,7 +22,7 @@ public static class AgentRunner
                 : $"--- Starting loop {i + 1} of {loops} ---";
             log(loopMessage);
 
-            var action = await PlanNextAction(goal, memory, llmProvider, log);
+            var action = await PlanNextAction(nextTask, memory, llmProvider, log);
             log($"Planner returned action: '{action}'");
 
             if (string.Equals(action, "done", StringComparison.OrdinalIgnoreCase))
@@ -71,9 +72,9 @@ public static class AgentRunner
             }
 
             log(result);
-            goal = result;
             if (executed)
             {
+                nextTask = result;
                 i++;
                 unknownCount = 0;
             }

--- a/tests/WorldSeed.Tests/AgentRunnerTests.cs
+++ b/tests/WorldSeed.Tests/AgentRunnerTests.cs
@@ -12,8 +12,10 @@ public class AgentRunnerTests
         {
             "chat What is the capital of France?",
             "The capital of France is Paris.",
+            "no",
             "chat What is the capital of Belgium?",
-            "The capital of Belgium is Brussels."
+            "The capital of Belgium is Brussels.",
+            "no"
         });
 
         var memory = await AgentRunner.RunAsync(
@@ -65,8 +67,10 @@ public class AgentRunnerTests
         {
             "chat step one",
             "result one",
+            "no",
             "chat step two",
             "result two",
+            "no",
             "done"
         });
 
@@ -84,13 +88,14 @@ public class AgentRunnerTests
         {
             "chat hi",
             "pong",
+            "no",
             "done"
         });
 
         await AgentRunner.RunAsync("test", provider, 0, _ => { });
 
         Assert.Contains("History: none", provider.Prompts[1]);
-        Assert.Contains("chat hi => pong", provider.Prompts[2]);
+        Assert.Contains("chat hi => pong", provider.Prompts[3]);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- ensure the agent keeps the initial goal constant while iterating
- store intermediate steps in a `nextTask` variable to advance toward the goal

## Testing
- `dotnet test tests/WorldSeed.Tests/WorldSeed.Tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68768582bd38832d8bacf601b6c913c8