### PR TITLE
Add CompareTool for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ format `<tool> <input>` or the single word `DONE`. If the returned tool name doe
 not match one of the registered tools the agent falls back to the `chat` tool.
 Ensure your language model is prompted to follow this format precisely. When
 using other models or custom prompts, verify that the first word corresponds to
-a valid tool name such as `chat`, `echo`, or `list`.
+a valid tool name such as `chat`, `echo`, `list`, or `compare`.
 
 When an unknown tool is encountered the agent reuses the `chat` tool to handle
 the response. Such fallbacks do not count toward the configured loop limit, but

--- a/src/Agent.Runtime/Tools/CompareTool.cs
+++ b/src/Agent.Runtime/Tools/CompareTool.cs
@@ -1,0 +1,21 @@
+using Shared.LLM;
+
+namespace Agent.Runtime.Tools;
+
+public class CompareTool : ITool
+{
+    public string Name => "compare";
+
+    private readonly ILLMProvider _provider;
+
+    public CompareTool(ILLMProvider provider)
+    {
+        _provider = provider;
+    }
+
+    public async Task<string> ExecuteAsync(string input)
+    {
+        var prompt = $"Compare the following options and choose the best one with a short reason: {input}";
+        return await _provider.CompleteAsync(prompt);
+    }
+}

--- a/src/Agent.Runtime/Tools/ToolRegistry.cs
+++ b/src/Agent.Runtime/Tools/ToolRegistry.cs
@@ -15,6 +15,7 @@ public static class ToolRegistry
         Register(new EchoTool());
         Register(new ChatTool(llmProvider, memory));
         Register(new ListTool(llmProvider));
+        Register(new CompareTool(llmProvider));
     }
 
     public static void Register(ITool tool)

--- a/tests/WorldSeed.Tests/ToolRegistryTests.cs
+++ b/tests/WorldSeed.Tests/ToolRegistryTests.cs
@@ -13,11 +13,13 @@ public class ToolRegistryTests
         Assert.NotNull(ToolRegistry.Get("echo"));
         Assert.NotNull(ToolRegistry.Get("chat"));
         Assert.NotNull(ToolRegistry.Get("list"));
+        Assert.NotNull(ToolRegistry.Get("compare"));
 
         // retrieval should be case-insensitive
         Assert.NotNull(ToolRegistry.Get("ECHO"));
         Assert.NotNull(ToolRegistry.Get("CHAT"));
         Assert.NotNull(ToolRegistry.Get("LIST"));
+        Assert.NotNull(ToolRegistry.Get("COMPARE"));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- introduce `CompareTool` for easy evaluation
- register the new tool
- mention it in README
- test that `compare` is registered in `ToolRegistry`

## Testing
- `dotnet test --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_68769187cf64832d88070afd664794d3