### PR TITLE
Implement Overseer Agent system

### DIFF
--- a/src/Orchestrator.API/Controllers/OverseerController.cs
+++ b/src/Orchestrator.API/Controllers/OverseerController.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNetCore.Mvc;
+using Orchestrator.API.Services;
+using Shared.Models;
+
+namespace Orchestrator.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class OverseerController : ControllerBase
+{
+    private readonly OverseerService _overseer;
+
+    public OverseerController(OverseerService overseer)
+    {
+        _overseer = overseer;
+    }
+
+    [HttpPost("start")]
+    public async Task<IActionResult> Start([FromBody] StartOverseerRequest request)
+    {
+        var id = await _overseer.StartAsync(request.Goal, request.Loops);
+        return Ok(new { id });
+    }
+
+    [HttpPost("{id}/stop")]
+    public async Task<IActionResult> Stop(string id)
+    {
+        await _overseer.StopAsync(id);
+        return Ok();
+    }
+
+    [HttpGet("list")]
+    public IActionResult List()
+    {
+        var result = _overseer.List();
+        return Ok(result);
+    }
+
+    [HttpGet("{id}/status")]
+    public async Task<IActionResult> Status(string id)
+    {
+        var status = await _overseer.GetStatusAsync(id);
+        if (status == null)
+            return NotFound();
+        return Ok(status);
+    }
+}

--- a/src/Orchestrator.API/Services/OverseerService.cs
+++ b/src/Orchestrator.API/Services/OverseerService.cs
@@ -1,0 +1,63 @@
+using Shared.Models;
+using System.Collections.Concurrent;
+
+namespace Orchestrator.API.Services;
+
+public class OverseerService
+{
+    private readonly AgentOrchestrator _agents;
+    private readonly ConcurrentDictionary<string, OverseerInfo> _overseers = new();
+
+    public OverseerService(AgentOrchestrator agents)
+    {
+        _agents = agents;
+    }
+
+    public async Task<string> StartAsync(string goal, int loops = 5)
+    {
+        var id = Guid.NewGuid().ToString("N");
+        var subgoals = DecomposeGoal(goal);
+        var agentIds = new List<string>();
+        foreach (var g in subgoals)
+        {
+            var agentId = await _agents.StartAgentAsync(g, AgentType.Default, loops);
+            agentIds.Add(agentId);
+        }
+        _overseers[id] = new OverseerInfo(id, goal, agentIds);
+        return id;
+    }
+
+    public IEnumerable<OverseerInfo> List() => _overseers.Values;
+
+    public async Task<OverseerStatus?> GetStatusAsync(string id)
+    {
+        if (!_overseers.TryGetValue(id, out var info))
+            return null;
+        var logs = new Dictionary<string, List<string>>();
+        foreach (var agentId in info.AgentIds)
+        {
+            var messages = await _agents.GetAllMessagesAsync(agentId);
+            logs[agentId] = messages;
+        }
+        return new OverseerStatus(info, logs);
+    }
+
+    public async Task StopAsync(string id)
+    {
+        if (!_overseers.TryRemove(id, out var info))
+            return;
+        foreach (var agentId in info.AgentIds)
+            await _agents.StopAgentAsync(agentId);
+    }
+
+    private static List<string> DecomposeGoal(string goal)
+    {
+        var parts = goal.Split(new[] { '.', '\n', ';' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(p => p.Trim())
+            .Where(p => !string.IsNullOrEmpty(p))
+            .ToList();
+        if (parts.Count <= 1)
+            parts = new List<string> { goal };
+        return parts;
+    }
+}

--- a/src/Orchestrator.API/Services/OverseerService.cs
+++ b/src/Orchestrator.API/Services/OverseerService.cs
@@ -6,48 +6,121 @@ namespace Orchestrator.API.Services;
 public class OverseerService
 {
     private readonly AgentOrchestrator _agents;
-    private readonly ConcurrentDictionary<string, OverseerInfo> _overseers = new();
+
+    private class OverseerState
+    {
+        public string Id { get; }
+        public string Goal { get; }
+        public int Loops { get; }
+        public List<string> AgentIds { get; } = new();
+        public CancellationTokenSource Cancellation { get; } = new();
+
+        public OverseerState(string id, string goal, int loops)
+        {
+            Id = id;
+            Goal = goal;
+            Loops = loops;
+        }
+    }
+
+    private readonly ConcurrentDictionary<string, OverseerState> _overseers = new();
 
     public OverseerService(AgentOrchestrator agents)
     {
         _agents = agents;
     }
 
-    public async Task<string> StartAsync(string goal, int loops = 5)
+    public Task<string> StartAsync(string goal, int loops = 5)
     {
         var id = Guid.NewGuid().ToString("N");
         var subgoals = DecomposeGoal(goal);
-        var agentIds = new List<string>();
-        foreach (var g in subgoals)
-        {
-            var agentId = await _agents.StartAgentAsync(g, AgentType.Default, loops);
-            agentIds.Add(agentId);
-        }
-        _overseers[id] = new OverseerInfo(id, goal, agentIds);
-        return id;
+        var state = new OverseerState(id, goal, loops);
+        _overseers[id] = state;
+
+        _ = Task.Run(() => RunAsync(state, subgoals));
+
+        return Task.FromResult(id);
     }
 
-    public IEnumerable<OverseerInfo> List() => _overseers.Values;
+    public IEnumerable<OverseerInfo> List() =>
+        _overseers.Values.Select(o => new OverseerInfo(o.Id, o.Goal, o.AgentIds.ToList()));
 
     public async Task<OverseerStatus?> GetStatusAsync(string id)
     {
-        if (!_overseers.TryGetValue(id, out var info))
+        if (!_overseers.TryGetValue(id, out var state))
             return null;
+
+        var info = new OverseerInfo(state.Id, state.Goal, state.AgentIds.ToList());
         var logs = new Dictionary<string, List<string>>();
-        foreach (var agentId in info.AgentIds)
+        foreach (var agentId in state.AgentIds)
         {
             var messages = await _agents.GetAllMessagesAsync(agentId);
             logs[agentId] = messages;
         }
+
         return new OverseerStatus(info, logs);
     }
 
     public async Task StopAsync(string id)
     {
-        if (!_overseers.TryRemove(id, out var info))
+        if (!_overseers.TryRemove(id, out var state))
             return;
-        foreach (var agentId in info.AgentIds)
+
+        state.Cancellation.Cancel();
+
+        foreach (var agentId in state.AgentIds)
             await _agents.StopAgentAsync(agentId);
+    }
+
+    private async Task RunAsync(OverseerState state, List<string> subgoals)
+    {
+        foreach (var goal in subgoals)
+        {
+            await HandleSubgoalAsync(state, goal);
+        }
+    }
+
+    private async Task HandleSubgoalAsync(OverseerState state, string subgoal)
+    {
+        var attempt = 1;
+        var currentGoal = subgoal;
+        while (!state.Cancellation.IsCancellationRequested)
+        {
+            var agentId = await _agents.StartAgentAsync(currentGoal, AgentType.Default, state.Loops);
+            state.AgentIds.Add(agentId);
+
+            var completed = await WaitForCompletionAsync(agentId, state.Loops, state.Cancellation.Token);
+
+            await _agents.StopAgentAsync(agentId);
+
+            if (completed)
+                break;
+
+            attempt++;
+            currentGoal = $"{subgoal} (attempt {attempt})";
+        }
+    }
+
+    private async Task<bool> WaitForCompletionAsync(string agentId, int loops, CancellationToken token)
+    {
+        var elapsed = 0;
+        while (!token.IsCancellationRequested && elapsed < loops * 10000)
+        {
+            var logs = await _agents.GetAllMessagesAsync(agentId);
+            if (logs.Any(l => l.Contains("LLM signaled DONE", StringComparison.OrdinalIgnoreCase) ||
+                              l.Contains("Planner indicated completion", StringComparison.OrdinalIgnoreCase)))
+            {
+                return true;
+            }
+
+            if (logs.Any(l => l.Contains("Agent completed loops")))
+                break;
+
+            await Task.Delay(1000, token);
+            elapsed += 1000;
+        }
+
+        return false;
     }
 
     private static List<string> DecomposeGoal(string goal)

--- a/src/Orchestrator.API/Services/ServiceCollectionExtensions.cs
+++ b/src/Orchestrator.API/Services/ServiceCollectionExtensions.cs
@@ -8,6 +8,13 @@ public static class ServiceCollectionExtensions
     {
         services.AddSingleton<Data.IUnitOfWork, Data.InMemoryUnitOfWork>();
         services.AddSingleton<AgentOrchestrator>();
+
+        var apiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+        Shared.LLM.ILLMProvider llm = string.IsNullOrWhiteSpace(apiKey)
+            ? new Shared.LLM.MockOpenAIProvider()
+            : new Shared.LLM.OpenAIProvider(apiKey);
+        services.AddSingleton(llm);
+
         services.AddSingleton<OverseerService>();
         return services;
     }

--- a/src/Orchestrator.API/Services/ServiceCollectionExtensions.cs
+++ b/src/Orchestrator.API/Services/ServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ public static class ServiceCollectionExtensions
     {
         services.AddSingleton<Data.IUnitOfWork, Data.InMemoryUnitOfWork>();
         services.AddSingleton<AgentOrchestrator>();
+        services.AddSingleton<OverseerService>();
         return services;
     }
 }

--- a/src/Orchestrator.UI/Components/Layout/NavMenu.razor
+++ b/src/Orchestrator.UI/Components/Layout/NavMenu.razor
@@ -31,6 +31,11 @@
             </NavLink>
         </div>
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="overseers">
+                <span class="bi bi-diagram-3" aria-hidden="true"></span> Overseers
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="logs">
                 <span class="bi bi-journal-text" aria-hidden="true"></span> Logs
             </NavLink>

--- a/src/Orchestrator.UI/Components/Layout/NavMenu.razor
+++ b/src/Orchestrator.UI/Components/Layout/NavMenu.razor
@@ -36,6 +36,11 @@
             </NavLink>
         </div>
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="overseer-logs">
+                <span class="bi bi-journal-text" aria-hidden="true"></span> Overseer Logs
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="logs">
                 <span class="bi bi-journal-text" aria-hidden="true"></span> Logs
             </NavLink>

--- a/src/Orchestrator.UI/Components/Pages/OverseerLogs.razor
+++ b/src/Orchestrator.UI/Components/Pages/OverseerLogs.razor
@@ -1,0 +1,112 @@
+@page "/overseer-logs"
+@rendermode InteractiveServer
+@using Shared.Models
+@inject HttpClient Http
+@implements IDisposable
+
+<PageTitle>Overseer Logs</PageTitle>
+
+<h1>Overseer Logs</h1>
+
+<div class="mb-3">
+    <select class="form-select" value="@selectedOverseerId" @onchange="OnOverseerChanged">
+        <option value="">-- Select Overseer --</option>
+        @foreach (var o in overseers)
+        {
+            <option value="@o.Id">@o.Id</option>
+        }
+    </select>
+</div>
+
+@if (selectedOverseer != null)
+{
+    <div class="mb-3">
+        <select class="form-select" value="@selectedAgentId" @onchange="OnAgentChanged">
+            <option value="">-- Select Agent --</option>
+            @foreach (var id in selectedOverseer.AgentIds)
+            {
+                <option value="@id">@id</option>
+            }
+        </select>
+    </div>
+}
+
+@if (!string.IsNullOrEmpty(selectedAgentId))
+{
+    <pre class="border p-2" style="height:300px; overflow-y:auto">@string.Join("\n", messages)</pre>
+}
+
+@code {
+    private List<OverseerInfo> overseers = new();
+    private OverseerInfo? selectedOverseer;
+    private string? selectedOverseerId;
+    private string? selectedAgentId;
+    private readonly List<string> messages = new();
+    private CancellationTokenSource? _cts;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadOverseers();
+    }
+
+    private async Task LoadOverseers()
+    {
+        var result = await Http.GetFromJsonAsync<List<OverseerInfo>>("api/overseer/list");
+        if (result != null)
+            overseers = result;
+    }
+
+    private async void OnOverseerChanged(ChangeEventArgs e)
+    {
+        _cts?.Cancel();
+        messages.Clear();
+        selectedOverseerId = e.Value?.ToString();
+        selectedAgentId = null;
+        selectedOverseer = overseers.FirstOrDefault(o => o.Id == selectedOverseerId);
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private void OnAgentChanged(ChangeEventArgs e)
+    {
+        _cts?.Cancel();
+        messages.Clear();
+        selectedAgentId = e.Value?.ToString();
+        if (!string.IsNullOrEmpty(selectedOverseerId) && !string.IsNullOrEmpty(selectedAgentId))
+        {
+            _cts = new CancellationTokenSource();
+            _ = PollLogsAsync(_cts.Token);
+        }
+    }
+
+    private async Task PollLogsAsync(CancellationToken token)
+    {
+        var timer = new PeriodicTimer(TimeSpan.FromSeconds(2));
+        try
+        {
+            while (await timer.WaitForNextTickAsync(token))
+            {
+                await RefreshLogs();
+                await InvokeAsync(StateHasChanged);
+            }
+        }
+        catch (OperationCanceledException) { }
+    }
+
+    private async Task RefreshLogs()
+    {
+        if (string.IsNullOrEmpty(selectedOverseerId) || string.IsNullOrEmpty(selectedAgentId))
+            return;
+
+        var status = await Http.GetFromJsonAsync<OverseerStatus>($"api/overseer/{selectedOverseerId}/status");
+        if (status != null && status.Logs.TryGetValue(selectedAgentId, out var logs))
+        {
+            messages.Clear();
+            messages.AddRange(logs);
+        }
+    }
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+    }
+}

--- a/src/Orchestrator.UI/Components/Pages/OverseerLogs.razor
+++ b/src/Orchestrator.UI/Components/Pages/OverseerLogs.razor
@@ -29,6 +29,13 @@
             }
         </select>
     </div>
+    <h3>Overseer</h3>
+    <pre class="border p-2" style="height:200px; overflow-y:auto">@string.Join("\n", overseerMessages)</pre>
+    @if (!string.IsNullOrEmpty(result))
+    {
+        <h4>Result</h4>
+        <pre class="border p-2">@result</pre>
+    }
 }
 
 @if (!string.IsNullOrEmpty(selectedAgentId))
@@ -42,6 +49,8 @@
     private string? selectedOverseerId;
     private string? selectedAgentId;
     private readonly List<string> messages = new();
+    private readonly List<string> overseerMessages = new();
+    private string? result;
     private CancellationTokenSource? _cts;
 
     protected override async Task OnInitializedAsync()
@@ -60,9 +69,16 @@
     {
         _cts?.Cancel();
         messages.Clear();
+        overseerMessages.Clear();
+        result = null;
         selectedOverseerId = e.Value?.ToString();
         selectedAgentId = null;
         selectedOverseer = overseers.FirstOrDefault(o => o.Id == selectedOverseerId);
+        if (selectedOverseerId != null)
+        {
+            _cts = new CancellationTokenSource();
+            _ = PollStatusAsync(_cts.Token);
+        }
         await InvokeAsync(StateHasChanged);
     }
 
@@ -71,37 +87,43 @@
         _cts?.Cancel();
         messages.Clear();
         selectedAgentId = e.Value?.ToString();
-        if (!string.IsNullOrEmpty(selectedOverseerId) && !string.IsNullOrEmpty(selectedAgentId))
+        if (!string.IsNullOrEmpty(selectedOverseerId))
         {
             _cts = new CancellationTokenSource();
-            _ = PollLogsAsync(_cts.Token);
+            _ = PollStatusAsync(_cts.Token);
         }
     }
 
-    private async Task PollLogsAsync(CancellationToken token)
+    private async Task PollStatusAsync(CancellationToken token)
     {
         var timer = new PeriodicTimer(TimeSpan.FromSeconds(2));
         try
         {
             while (await timer.WaitForNextTickAsync(token))
             {
-                await RefreshLogs();
+                await RefreshStatus();
                 await InvokeAsync(StateHasChanged);
             }
         }
         catch (OperationCanceledException) { }
     }
 
-    private async Task RefreshLogs()
+    private async Task RefreshStatus()
     {
-        if (string.IsNullOrEmpty(selectedOverseerId) || string.IsNullOrEmpty(selectedAgentId))
+        if (string.IsNullOrEmpty(selectedOverseerId))
             return;
 
         var status = await Http.GetFromJsonAsync<OverseerStatus>($"api/overseer/{selectedOverseerId}/status");
-        if (status != null && status.Logs.TryGetValue(selectedAgentId, out var logs))
+        if (status != null)
         {
-            messages.Clear();
-            messages.AddRange(logs);
+            overseerMessages.Clear();
+            overseerMessages.AddRange(status.OverseerLogs);
+            result = status.Result;
+            if (!string.IsNullOrEmpty(selectedAgentId) && status.Logs.TryGetValue(selectedAgentId, out var logs))
+            {
+                messages.Clear();
+                messages.AddRange(logs);
+            }
         }
     }
 

--- a/src/Orchestrator.UI/Components/Pages/Overseers.razor
+++ b/src/Orchestrator.UI/Components/Pages/Overseers.razor
@@ -1,0 +1,68 @@
+@page "/overseers"
+@rendermode InteractiveServer
+@inject HttpClient Http
+@using Shared.Models
+
+<PageTitle>Overseers</PageTitle>
+
+<h1>Overseers</h1>
+
+<div class="mb-3">
+    <input class="form-control" placeholder="Goal" @bind="goal" />
+</div>
+<div class="mb-3">
+    <input type="number" class="form-control" placeholder="Loops" @bind="loops" />
+</div>
+<button class="btn btn-primary" @onclick="StartOverseer">Start Overseer</button>
+
+<h2 class="mt-4">Active Overseers</h2>
+<ul>
+    @foreach (var o in overseers)
+    {
+        <li>@o.Id
+            <button class="btn btn-sm btn-danger ms-2" @onclick="() => Stop(o.Id)">Stop</button>
+            <ul>
+                @foreach (var aid in o.AgentIds)
+                {
+                    <li>@aid</li>
+                }
+            </ul>
+        </li>
+    }
+</ul>
+
+@code {
+    private string goal = string.Empty;
+    private int loops = 5;
+    private List<OverseerInfo> overseers = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        await Load();
+    }
+
+    private async Task Load()
+    {
+        var result = await Http.GetFromJsonAsync<List<OverseerInfo>>("api/overseer/list");
+        if (result != null)
+            overseers = result;
+    }
+
+    private async Task StartOverseer()
+    {
+        var req = new StartOverseerRequest(goal, loops);
+        var resp = await Http.PostAsJsonAsync("api/overseer/start", req);
+        if (resp.IsSuccessStatusCode)
+        {
+            await Load();
+            goal = string.Empty;
+            loops = 5;
+        }
+    }
+
+    private async Task Stop(string id)
+    {
+        await Http.PostAsync($"api/overseer/{id}/stop", null);
+        await Load();
+    }
+}

--- a/src/Shared/Models/OverseerInfo.cs
+++ b/src/Shared/Models/OverseerInfo.cs
@@ -1,0 +1,3 @@
+namespace Shared.Models;
+
+public record OverseerInfo(string Id, string Goal, List<string> AgentIds);

--- a/src/Shared/Models/OverseerStatus.cs
+++ b/src/Shared/Models/OverseerStatus.cs
@@ -1,0 +1,3 @@
+namespace Shared.Models;
+
+public record OverseerStatus(OverseerInfo Info, Dictionary<string, List<string>> Logs);

--- a/src/Shared/Models/OverseerStatus.cs
+++ b/src/Shared/Models/OverseerStatus.cs
@@ -1,3 +1,7 @@
 namespace Shared.Models;
 
-public record OverseerStatus(OverseerInfo Info, Dictionary<string, List<string>> Logs);
+public record OverseerStatus(
+    OverseerInfo Info,
+    Dictionary<string, List<string>> Logs,
+    List<string> OverseerLogs,
+    string? Result);

--- a/src/Shared/Models/StartOverseerRequest.cs
+++ b/src/Shared/Models/StartOverseerRequest.cs
@@ -1,0 +1,3 @@
+namespace Shared.Models;
+
+public record StartOverseerRequest(string Goal, int Loops = 5);

--- a/tests/WorldSeed.Tests/OverseerServiceTests.cs
+++ b/tests/WorldSeed.Tests/OverseerServiceTests.cs
@@ -1,5 +1,6 @@
 using Orchestrator.API.Services;
 using Shared.Models;
+using Shared.LLM;
 using System.Linq;
 
 namespace WorldSeed.Tests;
@@ -12,7 +13,7 @@ public class OverseerServiceTests
         Environment.SetEnvironmentVariable("USE_LOCAL_AGENT", "1");
         var uow = new Orchestrator.API.Data.InMemoryUnitOfWork();
         var orchestrator = new AgentOrchestrator(uow);
-        var overseer = new OverseerService(orchestrator);
+        var overseer = new OverseerService(orchestrator, new MockOpenAIProvider());
 
         var id = await overseer.StartAsync("task one. task two.", 1);
         OverseerInfo info = overseer.List().First(o => o.Id == id);
@@ -33,7 +34,7 @@ public class OverseerServiceTests
         Environment.SetEnvironmentVariable("USE_LOCAL_AGENT", "1");
         var uow = new Orchestrator.API.Data.InMemoryUnitOfWork();
         var orchestrator = new AgentOrchestrator(uow);
-        var overseer = new OverseerService(orchestrator);
+        var overseer = new OverseerService(orchestrator, new MockOpenAIProvider());
 
         var id = await overseer.StartAsync("echo one. echo two.", 1);
 
@@ -60,7 +61,7 @@ public class OverseerServiceTests
         Environment.SetEnvironmentVariable("USE_LOCAL_AGENT", "1");
         var uow = new Orchestrator.API.Data.InMemoryUnitOfWork();
         var orchestrator = new AgentOrchestrator(uow);
-        var overseer = new OverseerService(orchestrator);
+        var overseer = new OverseerService(orchestrator, new MockOpenAIProvider());
 
         var id = await overseer.StartAsync("echo", 1);
 

--- a/tests/WorldSeed.Tests/OverseerServiceTests.cs
+++ b/tests/WorldSeed.Tests/OverseerServiceTests.cs
@@ -1,0 +1,51 @@
+using Orchestrator.API.Services;
+using Shared.Models;
+using System.Linq;
+
+namespace WorldSeed.Tests;
+
+public class OverseerServiceTests
+{
+    [Fact]
+    public async Task StartAndStopOverseer_CreatesAgents()
+    {
+        Environment.SetEnvironmentVariable("USE_LOCAL_AGENT", "1");
+        var uow = new Orchestrator.API.Data.InMemoryUnitOfWork();
+        var orchestrator = new AgentOrchestrator(uow);
+        var overseer = new OverseerService(orchestrator);
+
+        var id = await overseer.StartAsync("task one. task two.");
+        var info = overseer.List().First(o => o.Id == id);
+        Assert.True(info.AgentIds.Count >= 2);
+
+        await overseer.StopAsync(id);
+        Assert.Empty(overseer.List());
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_ReturnsLogsForAgents()
+    {
+        Environment.SetEnvironmentVariable("USE_LOCAL_AGENT", "1");
+        var uow = new Orchestrator.API.Data.InMemoryUnitOfWork();
+        var orchestrator = new AgentOrchestrator(uow);
+        var overseer = new OverseerService(orchestrator);
+
+        var id = await overseer.StartAsync("echo one. echo two.", 1);
+
+        OverseerStatus? status = null;
+        for (var i = 0; i < 10; i++)
+        {
+            await Task.Delay(500);
+            status = await overseer.GetStatusAsync(id);
+            if (status != null && status.Logs.Values.All(l => l.Count > 0))
+                break;
+        }
+        Assert.NotNull(status);
+        foreach (var list in status!.Logs.Values)
+        {
+            Assert.NotEmpty(list);
+        }
+
+        await overseer.StopAsync(id);
+    }
+}


### PR DESCRIPTION
## Summary
- add in-memory overseer service that spawns subagents
- expose overseer API controller for starting/stopping/listing
- register OverseerService
- add blazor page to manage overseers
- add new shared models for overseer messages
- add test for OverseerService
- add overseer status test

## Testing
- `dotnet test tests/WorldSeed.Tests/WorldSeed.Tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6876a45430c4832d9127ca1d8856bfa0