### PR TITLE
Improve overseer retry prompt

### DIFF
--- a/src/Orchestrator.API/Services/OverseerService.cs
+++ b/src/Orchestrator.API/Services/OverseerService.cs
@@ -124,7 +124,12 @@ public class OverseerService
             }
 
             attempt++;
-            currentGoal = $"{subgoal} (attempt {attempt})";
+            var lastLog = logs.LastOrDefault() ?? "none";
+            var improvPrompt =
+                $"We attempted the subgoal '{currentGoal}' but did not complete it. " +
+                $"Last result: '{lastLog}'. Suggest a short alternative approach to accomplish this subgoal.";
+            var newApproach = await _llm.CompleteAsync(improvPrompt);
+            currentGoal = $"{newApproach.Trim()} (attempt {attempt})";
             state.Logs.Add($"Retrying subgoal '{subgoal}' as '{currentGoal}'");
         }
     }


### PR DESCRIPTION
## Summary
- enhance OverseerService retry logic
  - when a subgoal attempt fails, ask the LLM to suggest a new approach
  - update the subgoal prompt with the new approach before retrying

## Testing
- `dotnet test tests/WorldSeed.Tests/WorldSeed.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6876afe70ea8832d8c525326fe05f4ef