### PR TITLE
Fix agent logs dropdown in Overseer UI

### DIFF
--- a/src/Orchestrator.UI/Components/Pages/OverseerLogs.razor
+++ b/src/Orchestrator.UI/Components/Pages/OverseerLogs.razor
@@ -82,7 +82,7 @@
         await InvokeAsync(StateHasChanged);
     }
 
-    private void OnAgentChanged(ChangeEventArgs e)
+    private async Task OnAgentChanged(ChangeEventArgs e)
     {
         _cts?.Cancel();
         messages.Clear();
@@ -92,6 +92,7 @@
             _cts = new CancellationTokenSource();
             _ = PollStatusAsync(_cts.Token);
         }
+        await InvokeAsync(StateHasChanged);
     }
 
     private async Task PollStatusAsync(CancellationToken token)


### PR DESCRIPTION
## Summary
- show agent logs immediately when selecting an agent

## Testing
- `dotnet test tests/WorldSeed.Tests/WorldSeed.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6876bdf5a574832da8a999b476044ae8