### PR TITLE
Remove sandbox security profiles

### DIFF
--- a/docker/profiles/seccomp-agent.json
+++ b/docker/profiles/seccomp-agent.json
@@ -1,9 +1,0 @@
-{
-    "defaultAction": "SCMP_ACT_ERRNO",
-    "architectures": ["SCMP_ARCH_X86_64"],
-    "syscalls": [
-        {"names": ["exit", "exit_group", "read", "write", "futex"], "action": "SCMP_ACT_ALLOW"},
-        {"names": ["brk", "mmap", "mprotect", "munmap"], "action": "SCMP_ACT_ALLOW"},
-        {"names": ["clone", "execve"], "action": "SCMP_ACT_ALLOW"}
-    ]
-}

--- a/docker/profiles/worldseed-agent.apparmor
+++ b/docker/profiles/worldseed-agent.apparmor
@@ -1,9 +1,0 @@
-#include <tunables/global>
-
-profile worldseed-agent flags=(attach_disconnected) {
-    # Basic read/write access within the container
-    /agent/** rwk,
-    /usr/bin/dotnet ix,
-    network inet stream,
-    capability net_bind_service,
-}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,12 +14,10 @@ When Docker is unavailable the orchestrator can fall back to launching the agent
 process locally.
 
 Container safeguards include:
-
 - **Resource Limits** – CPU and memory quotas applied per container.
 - **Volumes** – a dedicated `/agent` volume is mounted for state.
 - **Network** – can be disabled per agent for offline execution.
-- **Seccomp Profile** – `docker/profiles/seccomp-agent.json` restricts system calls.
-- **AppArmor** – profile `worldseed-agent` confines filesystem and network access.
+- **No Security Profiles** – containers run with root privileges and no additional seccomp or AppArmor restrictions, so agents can modify the environment freely.
 
 The orchestrator passes these options when launching each container.
 This logic is implemented in `AgentOrchestrator` via Docker.DotNet's `HostConfig` settings.


### PR DESCRIPTION
## Summary
- remove seccomp and AppArmor profiles
- update architecture docs to note containers run without security profiles

## Testing
- `dotnet build tests/WorldSeed.Tests/WorldSeed.Tests.csproj -c Debug`
- `dotnet test tests/WorldSeed.Tests/WorldSeed.Tests.csproj --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6887dc870e94832db474c303780c0c3e