### PR TITLE
Improve agent command handling

### DIFF
--- a/src/Agent.Runtime/Tools/TerminalTool.cs
+++ b/src/Agent.Runtime/Tools/TerminalTool.cs
@@ -6,24 +6,47 @@ public class TerminalTool : ITool
 {
     public string Name => "terminal";
 
+    /// <summary>
+    /// The exit code from the last executed command.
+    /// </summary>
+    public int LastExitCode { get; private set; } = -1;
+
     public async Task<string> ExecuteAsync(string input)
     {
         if (string.IsNullOrWhiteSpace(input))
             return "No command provided";
 
-        var psi = new ProcessStartInfo("bash", $"-c \"{input}\"")
+        input = Normalize(input);
+
+        var psi = new ProcessStartInfo("bash")
         {
             RedirectStandardOutput = true,
             RedirectStandardError = true,
-            UseShellExecute = false
+            UseShellExecute = false,
         };
+        psi.ArgumentList.Add("-c");
+        psi.ArgumentList.Add(input);
 
         using var proc = Process.Start(psi);
         if (proc == null)
             return "Failed to start shell";
+
         string output = await proc.StandardOutput.ReadToEndAsync();
         string error = await proc.StandardError.ReadToEndAsync();
         await proc.WaitForExitAsync();
+        LastExitCode = proc.ExitCode;
+
         return proc.ExitCode == 0 ? output : string.IsNullOrWhiteSpace(error) ? output : error;
+    }
+
+    private static string Normalize(string cmd)
+    {
+        cmd = cmd.Trim();
+        if ((cmd.StartsWith("\"") && cmd.EndsWith("\"")) ||
+            (cmd.StartsWith("'") && cmd.EndsWith("'")))
+        {
+            cmd = cmd.Substring(1, cmd.Length - 2);
+        }
+        return cmd;
     }
 }


### PR DESCRIPTION
## Summary
- sanitize and validate planner actions
- integrate codex test after terminal steps
- recover from repeated terminal errors using a heredoc fallback
- normalize terminal commands and expose exit code

## Testing
- `dotnet build`
- `dotnet test` *(fails: `/tmp/MSBuildTemproot/.../docker: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6887f149d494832da1264b90f9a2ca22